### PR TITLE
ci: regenerate ci.yml + align scalafmt/scalafix + fix DisableSyntax.return debt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Check formatting
         run: sbt '++ ${{ matrix.scala }}' scalafmtCheckAll scalafmtSbtCheck
 
+      - name: Check scalafix
+        run: sbt '++ ${{ matrix.scala }}' 'scalafixAll --check'
+
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
 
@@ -86,11 +89,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: mkdir -p benchmarks/target target circe/target laws/target tests/target generics/target core/target project/target
+        run: mkdir -p jsoniter/target benchmarks/target target circe/target avro/target laws/target tests/target generics/target core/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: tar cf targets.tar benchmarks/target target circe/target laws/target tests/target generics/target core/target project/target
+        run: tar cf targets.tar jsoniter/target benchmarks/target target circe/target avro/target laws/target tests/target generics/target core/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -18,10 +18,17 @@ danglingParentheses.ctrlSite = true
 // misparses the specs2 `"…" should { … }` / `>> { … }` DSL on
 // our test files as orphan parens. The remaining rules are safe
 // for both the specs2 suites and the production sources.
+//
+// `AsciiSortImports` dropped because it sorts selectors uppercase-
+// first (`{JsonValueCodec, readFromSubArray}`) while scalafix's
+// `OrganizeImports { importSelectorsOrder = SymbolsFirst }` sorts
+// lowercase-first (`{readFromSubArray, JsonValueCodec}`). Running
+// both back-to-back makes the tools undo each other. Standard
+// resolution: let scalafix own import sorting, since it also handles
+// grouping and unused-import removal.
 rewrite.rules = [
   AvoidInfix
   RedundantParens
-  AsciiSortImports
   SortModifiers
   PreferCurlyFors
 ]

--- a/jsoniter/src/main/scala/dev/constructive/eo/jsoniter/JsonPathScanner.scala
+++ b/jsoniter/src/main/scala/dev/constructive/eo/jsoniter/JsonPathScanner.scala
@@ -1,5 +1,15 @@
 package dev.constructive.eo.jsoniter
 
+// Project policy bans `return` (DisableSyntax.return). This module is the
+// one deliberate exception: every method is a hot bytecode-level scan
+// that short-circuits on miss / hit. Translating each `return -1`,
+// `return pos + 1`, etc. into nested if/else or an outer @tailrec
+// helper would compile to the same JVM control flow but cost a lot of
+// readability — the imperative shape mirrors the JSON grammar the
+// scanner walks. Suppression is file-wide; do not lift these `return`s
+// elsewhere without re-reading this note.
+// scalafix:off DisableSyntax.return
+
 /** Hand-rolled JSON byte scanner. Resolves a [[PathStep]] list against an `Array[Byte]` JSON
   * document and returns the byte span `[start, end)` of the resolved value, or `-1` for the start
   * if the path doesn't match.

--- a/jsoniter/src/main/scala/dev/constructive/eo/jsoniter/JsoniterPrism.scala
+++ b/jsoniter/src/main/scala/dev/constructive/eo/jsoniter/JsoniterPrism.scala
@@ -1,7 +1,6 @@
 package dev.constructive.eo.jsoniter
 
-import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, readFromSubArray, writeToArray}
-
+import com.github.plokhotnyuk.jsoniter_scala.core.{readFromSubArray, writeToArray, JsonValueCodec}
 import dev.constructive.eo.data.Affine
 import dev.constructive.eo.optics.Optic
 

--- a/jsoniter/src/main/scala/dev/constructive/eo/jsoniter/JsoniterTraversal.scala
+++ b/jsoniter/src/main/scala/dev/constructive/eo/jsoniter/JsoniterTraversal.scala
@@ -1,7 +1,6 @@
 package dev.constructive.eo.jsoniter
 
-import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, readFromSubArray}
-
+import com.github.plokhotnyuk.jsoniter_scala.core.{readFromSubArray, JsonValueCodec}
 import dev.constructive.eo.data.{MultiFocus, PSVec}
 import dev.constructive.eo.optics.Optic
 

--- a/jsoniter/src/test/scala/dev/constructive/eo/jsoniter/JsoniterPrismSpec.scala
+++ b/jsoniter/src/test/scala/dev/constructive/eo/jsoniter/JsoniterPrismSpec.scala
@@ -4,11 +4,10 @@ import scala.language.implicitConversions
 
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
-import org.specs2.mutable.Specification
-
 import dev.constructive.eo.data.Affine
 import dev.constructive.eo.optics.Optic
 import dev.constructive.eo.optics.Optic.*
+import org.specs2.mutable.Specification
 
 /** Read-only spike for `JsoniterPrism`. Exercises:
   *

--- a/jsoniter/src/test/scala/dev/constructive/eo/jsoniter/JsoniterPrismWriteSpec.scala
+++ b/jsoniter/src/test/scala/dev/constructive/eo/jsoniter/JsoniterPrismWriteSpec.scala
@@ -4,12 +4,11 @@ import scala.language.implicitConversions
 
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
-import org.specs2.mutable.Specification
-
 import dev.constructive.eo.data.Affine
 import dev.constructive.eo.data.Affine.given
 import dev.constructive.eo.optics.Optic
 import dev.constructive.eo.optics.Optic.*
+import org.specs2.mutable.Specification
 
 /** Phase-2 write spec for `JsoniterPrism`. Exercises:
   *

--- a/jsoniter/src/test/scala/dev/constructive/eo/jsoniter/JsoniterPrismWriteSpec.scala
+++ b/jsoniter/src/test/scala/dev/constructive/eo/jsoniter/JsoniterPrismWriteSpec.scala
@@ -45,7 +45,9 @@ class JsoniterPrismWriteSpec extends Specification:
     val idP: Optic[Array[Byte], Array[Byte], Long, Long, Affine] =
       JsoniterPrism[Long]("$.payload.user.id")
     val out = idP.replace(1234567L)(sample)
-    str(out) === """{"payload":{"user":{"id":1234567,"email":"alice@example.com"},"items":[1,2,3]}}"""
+    str(
+      out
+    ) === """{"payload":{"user":{"id":1234567,"email":"alice@example.com"},"items":[1,2,3]}}"""
   }
 
   "JsoniterPrism .replace: shorter scalar — array shrinks, surrounding bytes preserved" >> {
@@ -82,7 +84,7 @@ class JsoniterPrismWriteSpec extends Specification:
     val written = idP.replace(99L)(sample)
     idP.to(written) match
       case h: Affine.Hit[idP.X, Long]  => h.b === 99L
-      case _: Affine.Miss[idP.X, Long] => (false === true)
+      case _: Affine.Miss[idP.X, Long] => false === true
   }
 
   "JsoniterPrism .modify(identity): byte-equivalent output for canonical encodings" >> {

--- a/jsoniter/src/test/scala/dev/constructive/eo/jsoniter/JsoniterTraversalSpec.scala
+++ b/jsoniter/src/test/scala/dev/constructive/eo/jsoniter/JsoniterTraversalSpec.scala
@@ -4,12 +4,11 @@ import scala.language.implicitConversions
 
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
-import org.specs2.mutable.Specification
-
-import dev.constructive.eo.data.{MultiFocus, PSVec}
 import dev.constructive.eo.data.MultiFocus.given
+import dev.constructive.eo.data.{MultiFocus, PSVec}
 import dev.constructive.eo.optics.Optic
 import dev.constructive.eo.optics.Optic.*
+import org.specs2.mutable.Specification
 
 /** Phase-1.5 spike for `JsoniterTraversal`. Exercises:
   *


### PR DESCRIPTION
## Summary

What started as a one-file scalafmt cleanup grew once CI surfaced three pre-existing debts.

### 1. `ci.yml` drift

`sbt githubWorkflowCheck` had been failing on every `main` run since the jsoniter + avro modules and the scalafix step landed without a corresponding regen. Running `sbt githubWorkflowGenerate` produces:

- Adds the missing **Check scalafix** step.
- Adds `jsoniter/target` + `avro/target` to the mkdir + tar lists.

Pure regenerated output, no hand-edits.

### 2. scalafmt ↔ scalafix import-sort conflict

With the `Check scalafix` step back in CI, the formatter and the linter were now both running — and they disagree about within-selector ordering:

- `.scalafmt.conf`'s `AsciiSortImports` sorts uppercase-first (`{JsonValueCodec, readFromSubArray}`).
- `.scalafix.conf`'s `OrganizeImports { importSelectorsOrder = SymbolsFirst }` sorts lowercase-first (`{readFromSubArray, JsonValueCodec}`).

Drop `AsciiSortImports` from `.scalafmt.conf`. Scalafix already owns import grouping and unused-import removal, so handing it sole ownership of within-selector ordering is the standard resolution. Re-sort the 5 affected jsoniter files via `sbt scalafixAll`.

### 3. `DisableSyntax.return` debt in `JsonPathScanner.scala`

The hand-rolled JSON byte scanner uses `return` to short-circuit match cases and tight `while` loops. Refactoring into nested if/else or @tailrec helpers would compile to identical JVM control flow but obscure the structure that mirrors the JSON grammar.

File-wide `// scalafix:off DisableSyntax.return` directive with a comment explaining the deliberate exception. The blanket project ban stays in force everywhere else.

### 4. Original goal: scalafmt JsoniterPrismWriteSpec

Two purely-mechanical fixes scalafmt would have applied on save — wrap a 100+ char line and strip redundant parens around a bare equality.

## Test plan

- [x] `sbt scalafmtCheckAll` — passes.
- [x] `sbt scalafixAll --check` — passes.
- [x] `sbt test` — 38 / 38 suites green.
- [x] `sbt docs/mdoc; docs/laikaSite` — clean.
- [ ] CI on this branch reaches green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)