### PR TITLE
docs(site): add constructive.dev favicon to right nav, left of GH

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -3,24 +3,39 @@ name: Deploy docs site
 # Builds the Laika/mdoc site via `sbt docs/tlSite` and publishes
 # the resulting static HTML to Cloudflare Pages.
 #
-# Two trigger paths:
+# Three trigger paths:
+#   - Pull request            → preview deployment tagged with the
+#                               head branch name; sticky comment lands
+#                               on the PR with the deployment URL.
 #   - Push to `main`           → preview deployment tagged `main-<sha>`
 #   - Tag push `v*`            → production deployment pinned to
 #                                the release version
 #
-# Both flows use the same Pages project (`cats-eo-docs` by
+# All three flows use the same Pages project (`cats-eo-docs` by
 # default); Cloudflare assigns each non-production deployment its
 # own preview URL while the production URL always reflects the
 # latest `v*` tag.
+#
+# Fork-PR caveat: secrets aren't exposed to workflows triggered by
+# PRs from forks, so this job silently no-ops for fork PRs. All
+# current contributors push branches inside the same repo, so this
+# is acceptable. Switch to `pull_request_target` if external
+# contributors need previews (with the usual security caveats).
 
 on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
   push:
     branches: [main]
     tags: [v*]
   workflow_dispatch:
 
 concurrency:
-  group: deploy-site-${{ github.ref }}
+  # Group by branch / PR so a new push to the same PR cancels the
+  # in-flight build. `github.head_ref` is set on PR events;
+  # `github.ref` covers pushes and tags.
+  group: deploy-site-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -28,12 +43,18 @@ jobs:
     name: Build and deploy to Cloudflare Pages
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    # Skip for PRs from forks — they can't access the Cloudflare
+    # secrets and would fail noisily.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       # `pages deploy` only needs a Cloudflare API token, but
       # keeping permissions minimal closes the "compromised
-      # workflow can push to the repo" blast radius.
+      # workflow can push to the repo" blast radius. PR runs also
+      # need pull-requests:write so the sticky comment step can
+      # post / update its message.
       contents: read
       deployments: write
+      pull-requests: write
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v6
@@ -54,11 +75,29 @@ jobs:
         run: sbt 'docs/tlSite'
 
       - name: Deploy to Cloudflare Pages
+        id: deploy
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # `github.head_ref` is the source branch on PR events;
+          # falls back to `github.ref_name` (`main`, `v0.x.y`, etc.)
+          # on push events.
           command: >-
             pages deploy site/target/docs/site
             --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT || 'cats-eo-docs' }}
-            --branch=${{ github.ref_name }}
+            --branch=${{ github.head_ref || github.ref_name }}
+
+      - name: Post preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cloudflare-pages-preview
+          message: |
+            :rocket: **Cloudflare Pages preview** for `${{ github.head_ref }}` is live:
+
+            ${{ steps.deploy.outputs.deployment-url }}
+
+            ${{ steps.deploy.outputs.pages-deployment-alias-url && format('Branch alias: {0}', steps.deploy.outputs.pages-deployment-alias-url) || '' }}
+
+            <sub>Built from commit `${{ github.event.pull_request.head.sha }}` · updated on every push.</sub>

--- a/build.sbt
+++ b/build.sbt
@@ -549,11 +549,18 @@ lazy val docs: Project = project
     //     $cp-sans / $cp-mono CSS variables in the main site.
     //   - OS-driven dark mode (prefers-color-scheme), augmented by a
     //     manual toggle injected from site/laika/js/cp-theme-toggle.js.
-    //   - Top nav: home -> https://www.constructive.dev/, plus a
-    //     GitHub icon link to the repo.
+    //   - Top nav: keep the Helium default home link (the small
+    //     home icon), and add an explicit pair of icons on the right
+    //     — constructive.dev favicon (back to the brand site) first,
+    //     GitHub source link second. To keep the favicon ahead of
+    //     the GitHub icon in display order, we suppress the GitHub
+    //     IconLink that `GenericSiteSettings` auto-derives from
+    //     `scmInfo` (it would otherwise prepend and force the wrong
+    //     order) and re-add it ourselves inside this call.
+    scmInfo := None,
     tlSiteHelium ~= {
       import laika.ast.{Image, Path}
-      import laika.helium.config.ImageLink
+      import laika.helium.config.{HeliumIcon, IconLink, ImageLink, TextLink}
       import laika.theme.config.Color
       _.all
         .themeColors(
@@ -583,14 +590,25 @@ lazy val docs: Project = project
         // overridden in site/docs/static/cp-theme.css instead.
         .site
         .topNavigationBar(
-          // Home link points back at the main brand site, using the
-          // constructive.dev favicon as the mark. GenericSiteSettings
-          // already adds a GitHub IconLink from scmInfo, so we don't
-          // add one explicitly here (otherwise we get duplicates).
-          homeLink = ImageLink.external(
-            "https://www.constructive.dev/",
-            Image.external("https://www.constructive.dev/assets/img/favicon.svg"),
-          )
+          // Home link: project name as a text link to the docs root.
+          // Helium's default home link (`DynamicHomeLink.default`)
+          // expects a configured landing page; we don't have one.
+          homeLink = TextLink.internal(Path.Root / "index.md", "cats-eo"),
+          // Right-side nav: constructive.dev favicon (back to brand
+          // site) first, GitHub source link second. Order matters —
+          // the auto-derived IconLink from scmInfo was suppressed
+          // above (scmInfo := None) so this list is the full set in
+          // the rendered order.
+          navLinks = Seq(
+            ImageLink.external(
+              "https://www.constructive.dev/",
+              Image.external("https://www.constructive.dev/assets/img/favicon.svg"),
+            ),
+            IconLink.external(
+              "https://github.com/Constructive-Programming/eo",
+              HeliumIcon.github,
+            ),
+          ),
         )
         .site
         .internalCSS(Path.Root / "static" / "cp-theme.css")

--- a/site/laika-static/static/cp-theme.css
+++ b/site/laika-static/static/cp-theme.css
@@ -84,3 +84,20 @@
   user-select: none;
 }
 #cp-theme-toggle:hover { color: var(--secondary-color); }
+
+/* ---- Right-nav constructive.dev favicon link ----------------------
+ * The favicon SVG ships with viewBox="0 0 64 64" but no explicit
+ * width or height attribute, so the browser renders it at 0 unless
+ * we give it an explicit size. Match the GitHub icon's visual
+ * weight: about 1.5rem square, vertically centered with the rest
+ * of the nav row.
+ */
+#top-bar .row.links .image-link {
+  display: inline-flex;
+  align-items: center;
+  height: var(--top-bar-height);
+}
+#top-bar .row.links .image-link img {
+  width: 1.5rem;
+  height: 1.5rem;
+}


### PR DESCRIPTION
## Summary

Quick link back to the main brand site, in the top-right nav beside the GitHub source link.

Previously the favicon was the home link in the centre of the top bar. Moved it to the right nav (left of the GitHub icon).

## Implementation

- **Home link** is now \`TextLink.internal(Path.Root / \"index.md\", \"cats-eo\")\`. Helium's default \`DynamicHomeLink\` needs a landing-page target and we don't have one.
- **Right-side navLinks** = \`Seq(favicon ImageLink, GH IconLink)\` in that order.
- **Suppress auto-derived GH IconLink** for the docs project via \`scmInfo := None\`. \`GenericSiteSettings.githubLink\` reads \`scmInfo\` and PREPENDS to navLinks, so without suppression we'd get the wrong order. \`scmInfo\` isn't used elsewhere in the docs project (\`publish / skip := true\`).
- **CSS sizing rule** for the favicon — the constructive.dev SVG ships without explicit width/height attributes (only \`viewBox=\"0 0 64 64\"\`), so the browser renders it at 0×0 without a CSS hint. Add a rule sizing it to 1.5rem to match the GH icon visual weight.

## Test plan

- [x] \`sbt docs/laikaSite\` builds cleanly.
- [x] Rendered top nav shows favicon → GH → toggle, in that order, both light and dark.
- [x] \`sbt scalafmtCheckAll; scalafixAll --check\` green.
- [ ] Cloudflare Pages preview comment lands on this PR (depends on #10 having merged first).

Built on top of #10 (Cloudflare PR-preview workflow). If #10 hasn't merged when this opens, this PR won't get a preview comment until #10 does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)