### PR TITLE
ci: drop dead peaceiris/actions-gh-pages publish step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,11 +272,3 @@ jobs:
 
       - name: Generate site
         run: sbt docs/tlSite
-
-      - name: Publish site
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: site/target/docs/site
-          keep_files: true

--- a/build.sbt
+++ b/build.sbt
@@ -513,6 +513,16 @@ lazy val docs: Project = project
   .settings(
     name := "cats-eo-docs",
     publish / skip := true,
+    // Disable sbt-typelevel-site's default ci.yml "Publish site" step.
+    // That step pushes the rendered site to a `gh-pages` branch via
+    // `peaceiris/actions-gh-pages`, but GitHub Pages is disabled on
+    // this repo — `gh-pages` is consumed by nothing. Production is
+    // served from Cloudflare Pages via .github/workflows/deploy-site.yml.
+    // Leaving the default on means every push to main also pushes a
+    // dead site to gh-pages, churns Dependabot on the peaceiris
+    // version, and burns CI minutes.
+    tlSitePublishBranch := None,
+    tlSitePublishTags := false,
     // Laika's input tree is mdoc's output by default. Append a
     // `laika-static/` sibling so we can ship hand-authored CSS / JS
     // (under `static/`) without putting them through mdoc, which


### PR DESCRIPTION
## Summary

\`sbt-typelevel-site\` emits a \"Publish site\" step in \`ci.yml\` that pushes the rendered docs to a \`gh-pages\` branch via \`peaceiris/actions-gh-pages@v4.0.0\` on every push to main. The flow predates the move to Cloudflare Pages:

- **GitHub Pages on this repo is disabled** (\`/repos/.../pages\` 404s).
- The \`gh-pages\` branch exists but is consumed by nothing.
- Cloudflare Pages is the actual production host, wired up in \`.github/workflows/deploy-site.yml\`.

Leaving the step means every main push pushes a dead site to \`gh-pages\`, Dependabot keeps churning on the peaceiris version (#7 is the current iteration), and CI minutes are spent on nothing.

Set \`tlSitePublishBranch := None\` and \`tlSitePublishTags := false\` for the docs project. Regenerated \`ci.yml\` drops the 8 lines that referenced peaceiris.

Closes the path that #7 was trying to update.

## Follow-up

After this lands:

- Close #7 (\`bump peaceiris/actions-gh-pages from 4.0.0 to 4.1.0\`) as obsolete.
- Optionally \`git push origin :gh-pages\` to delete the stale branch.

## Test plan

- [x] \`sbt githubWorkflowGenerate\` produces the regenerated ci.yml without manual edits.
- [x] \`sbt docs/laikaSite\` — builds clean.
- [x] \`sbt scalafmtCheckAll; scalafixAll --check\` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)