### PR TITLE
docs(site): rework cookbook — useful examples, not definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`Getter`s now compose with `Getter`s via `andThen`.** `g1.andThen(g2)` reads
   `s => g2.get(g1.get(s))` and yields a `Getter`, matching how `Iso` / `Lens`
   compose through their fused subclasses. `Getter.apply` now returns a concrete
-  `ReadGetter` carrying the fused `andThen` (previously a bare anonymous `Optic`
+  `DirectGetter` carrying the fused `andThen` (previously a bare anonymous `Optic`
   with no `andThen`, forcing callers to hand-nest `get` calls). As part of this,
   a `Getter`'s back-focus slot is now `Unit` (`Optic[S, Unit, A, Unit, Direct]`,
   was `Optic[S, Unit, A, A, Direct]`) — making the read-only-ness explicit in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Getter`s now compose with `Getter`s via `andThen`.** `g1.andThen(g2)` reads
+  `s => g2.get(g1.get(s))` and yields a `Getter`, matching how `Iso` / `Lens`
+  compose through their fused subclasses. `Getter.apply` now returns a concrete
+  `ReadGetter` carrying the fused `andThen` (previously a bare anonymous `Optic`
+  with no `andThen`, forcing callers to hand-nest `get` calls). As part of this,
+  a `Getter`'s back-focus slot is now `Unit` (`Optic[S, Unit, A, Unit, Direct]`,
+  was `Optic[S, Unit, A, A, Direct]`) — making the read-only-ness explicit in the
+  type and lining the inner `T` up with the outer `B` for composition. Pre-1.0,
+  no published baseline, so no MiMa break; external code that ascribed the full
+  `Optic[S, Unit, A, A, Direct]` type updates the final type argument to `Unit`.
+
 - **`Plated` — recursive self-traversal + recursion combinators.** A new
   `optics.Plated[S]` (the cats-eo analogue of Haskell `lens`'s `Plated`) whose
   `plate` is a `Traversal[S, S]` over the immediate same-typed children of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`Direct` is now an `opaque type`, not a transparent alias.** `Direct[X, A]`
+  was `type Direct[X, A] = A`, which the compiler dealiased to `A` during implicit
+  search — so `object Direct`'s givens (`Accessor[Direct]`, `AssociativeFunctor
+  [Direct, …]`, …) were *not* in the implicit scope of a bare `A`, and same-carrier
+  composition (`iso.andThen(iso)` via the generic path, `getter.andThen(getter)`)
+  couldn't summon them. `opaque type Direct[X, A] = A` makes `Direct` a distinct
+  type whose companion *is* in scope, so those givens resolve with no import and
+  the generic `andThen` works for `Direct`-carrier optics. It still erases to `A`
+  (zero runtime cost); `Direct.apply` (wrap) / `.value` (unwrap) are
+  `transparent inline` identities that compile away entirely, and exist only so
+  construction sites outside `object Direct` satisfy the type.
+  `Forget[F]` is decoupled from `Direct` (now `[X, A] =>> F[A]` directly, the same
+  type it always was) so the Fold/Forget machinery is unaffected. No behaviour
+  change; pre-1.0, no MiMa baseline.
+
 - **Identity carrier renamed `Forgetful` → `Direct`.** The carrier behind `Iso`
   and `Getter` (`type Direct[X, A] = A`) now reads as what it does — direct
   function application, no leftover — rather than naming the category-theory

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/AffineFoldBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/AffineFoldBench.scala
@@ -51,6 +51,17 @@ class AffineFoldBench extends JmhDefaults:
     mOpt3,
     mOpt6,
   }
+  import DomainOptics.{eoLoyaltyAF, mLoyalty, order, orderNoLoyalty}
+
+  // ---- canonical focus: customer.loyaltyId (Option[String]) ---------
+  // The advertised AffineFold focus, in memory. Monocle has no standalone
+  // AffineFold, so its peer is `Optional.getOption` (same as the depth rows).
+
+  @Benchmark def eoGetOption_loyalty: Option[String] = eoLoyaltyAF.getOption(order)
+  @Benchmark def mGetOption_loyalty: Option[String] = mLoyalty.getOption(order)
+
+  @Benchmark def eoGetOption_loyalty_empty: Option[String] = eoLoyaltyAF.getOption(orderNoLoyalty)
+  @Benchmark def mGetOption_loyalty_empty: Option[String] = mLoyalty.getOption(orderNoLoyalty)
 
   // ---- Composed EO Optionals narrowed to AffineFold via .getOption.
   //      The Monocle `mOpt3` / `mOpt6` peers live on the shared NestedOptics

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/GetterBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/GetterBench.scala
@@ -38,6 +38,14 @@ class GetterBench extends JmhDefaults:
     mGet6,
     mGetValue,
   }
+  import DomainOptics.{eoGetId, mGetId, order}
+
+  // ---- canonical scalar focus: order.id ($.id) ----------------------
+
+  @Benchmark def eoGet_orderId: Long = eoGetId.get(order)
+  @Benchmark def mGet_orderId: Long = mGetId.get(order)
+
+  // ---- Nested depth sweep (composition, which Order can't express) --
 
   @Benchmark def eoGet_0: Int = eoGetValue.get(leaf)
   @Benchmark def mGet_0: Int = mGetValue.get(leaf)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/GetterBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/GetterBench.scala
@@ -9,11 +9,11 @@ import dev.constructive.eo.bench.fixture.*
 /** `Getter.get` at the leaf plus deep composition, paired EO vs Monocle.
   *
   * EO `Getter`s are `Optic[S, Unit, A, Unit, Direct]` — both the leftover `T` and the back-focus
-  * `B` are `Unit`, so they compose through the ordinary `andThen` (the fused `ReadGetter.andThen`),
-  * just like `Iso` / `Lens`. The depth-3 / depth-6 rows therefore build a *composed* `Getter` on
-  * both sides (EO's `g3.andThen(g2)…` vs Monocle's `mG3.andThen(mG2)…`) and dispatch through it
-  * once — an apples-to-apples comparison, not EO's hand-nested `get` chain against Monocle's
-  * composed reader.
+  * `B` are `Unit`, so they compose through the ordinary `andThen` (the fused
+  * `DirectGetter.andThen`), just like `Iso` / `Lens`. The depth-3 / depth-6 rows therefore build a
+  * *composed* `Getter` on both sides (EO's `g3.andThen(g2)…` vs Monocle's `mG3.andThen(mG2)…`) and
+  * dispatch through it once — an apples-to-apples comparison, not EO's hand-nested `get` chain
+  * against Monocle's composed reader.
   */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/GetterBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/GetterBench.scala
@@ -5,15 +5,15 @@ import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
 
 import dev.constructive.eo.bench.fixture.*
-import dev.constructive.eo.data.Direct.given
 
-/** `Getter.get` at the leaf plus deep manual composition, paired EO vs Monocle.
+/** `Getter.get` at the leaf plus deep composition, paired EO vs Monocle.
   *
-  * '''Scope note.''' EO `Getter`s are `Optic[S, Unit, A, A, Direct]`; their T slot is fixed to
-  * `Unit`, which means two Getters cannot be composed via `Optic.andThen` (the outer B / inner T
-  * slots don't align). For depth-3 / depth-6 reads the bench chains `get` calls manually —
-  * `g4.get(g3.get(g2.get(g1.get(s))))` — matching what a user would write. Monocle's
-  * `Getter.andThen` (first-class on the trait) produces the equivalent composed reader on its side.
+  * EO `Getter`s are `Optic[S, Unit, A, Unit, Direct]` — both the leftover `T` and the back-focus
+  * `B` are `Unit`, so they compose through the ordinary `andThen` (the fused `ReadGetter.andThen`),
+  * just like `Iso` / `Lens`. The depth-3 / depth-6 rows therefore build a *composed* `Getter` on
+  * both sides (EO's `g3.andThen(g2)…` vs Monocle's `mG3.andThen(mG2)…`) and dispatch through it
+  * once — an apples-to-apples comparison, not EO's hand-nested `get` chain against Monocle's
+  * composed reader.
   */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -46,18 +46,18 @@ class GetterBench extends JmhDefaults:
   @Benchmark def mGet_orderId: Long = mGetId.get(order)
 
   // ---- Nested depth sweep (composition, which Order can't express) --
+  // Both sides build a composed Getter and dispatch through it once.
+
+  private val eoGet3 = eoG3.andThen(eoG2).andThen(eoG1).andThen(eoGetValue)
+
+  private val eoGet6 =
+    eoG6.andThen(eoG5).andThen(eoG4).andThen(eoG3).andThen(eoG2).andThen(eoG1).andThen(eoGetValue)
 
   @Benchmark def eoGet_0: Int = eoGetValue.get(leaf)
   @Benchmark def mGet_0: Int = mGetValue.get(leaf)
 
-  @Benchmark def eoGet_3: Int =
-    eoGetValue.get(eoG1.get(eoG2.get(eoG3.get(d3))))
+  @Benchmark def eoGet_3: Int = eoGet3.get(d3)
+  @Benchmark def mGet_3: Int = mGet3.get(d3)
 
-  @Benchmark def mGet_3: Int =
-    mGet3.get(d3)
-
-  @Benchmark def eoGet_6: Int =
-    eoGetValue.get(eoG1.get(eoG2.get(eoG3.get(eoG4.get(eoG5.get(eoG6.get(d6)))))))
-
-  @Benchmark def mGet_6: Int =
-    mGet6.get(d6)
+  @Benchmark def eoGet_6: Int = eoGet6.get(d6)
+  @Benchmark def mGet_6: Int = mGet6.get(d6)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/JsoniterBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/JsoniterBench.scala
@@ -1,57 +1,40 @@
 package dev.constructive.eo
 package bench
 
+import scala.compiletime.uninitialized
+
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
 
-import scala.language.implicitConversions
+import com.github.plokhotnyuk.jsoniter_scala.core.writeToArray
 
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
-import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import dev.constructive.eo.bench.fixture.*
+import dev.constructive.eo.data.MultiFocus.given
 
-import io.circe.{Codec, Json}
+import io.circe.Json
 import io.circe.parser.parse as circeParse
 
-import dev.constructive.eo.circe.{JsonPrism, codecPrism}
-import dev.constructive.eo.data.{Affine, MultiFocus, PSVec}
-import dev.constructive.eo.data.MultiFocus.given
-import dev.constructive.eo.jsoniter.{JsoniterPrism, JsoniterTraversal}
-import dev.constructive.eo.optics.{Optic, Traversal}
-import dev.constructive.eo.optics.Optic.*
-
-import hearth.kindlings.circederivation.KindlingsCodecAsObject
-
-/** Bench for `eo-jsoniter` vs `eo-circe` covering both read and write paths:
+/** `eo-jsoniter` vs `eo-circe` on the canonical [[Order]] — the cross-EO comparison the
+  * `Order*Bench` baselines don't cover (those pit one backend against native/naive/monocle).
   *
-  * **Read fixtures (phase 1 / 1.5):**
-  *   1. **Hit at depth 3, scalar (`Long`).** `$.payload.user.id` on a synthetic 1 KB JSON.
-  *      jsoniter's expected sweet spot — skip the AST, decode just the Long.
-  *   2. **Hit at depth 4, scalar (`String`).** `$.payload.user.profile.email`. Same shape one level
-  *      deeper to confirm the perf gap doesn't degrade with depth.
-  *   3. **Miss at depth 3.** `$.payload.user.absent`. Honest stress test: if the perf advantage
-  *      collapses when the path doesn't resolve (because both libraries have to walk most of the
-  *      document anyway), the perf story is more nuanced.
-  *   4. **`[*]` fold-sum over 10-element array.** `$.payload.items[*]`. Phase-1.5 traversal.
+  * eo-jsoniter walks the raw `Array[Byte]`; eo-circe parses the same bytes to an AST and drills it.
+  * Parsing is part of eo-circe's realistic workflow, so the `c*` rows always `circeParse(bytes)`
+  * first — the comparison is "byte-walk" vs "parse + AST-walk" on identical input.
   *
-  * **Write fixtures (phase 2):**
-  *   5. **`.replace` at depth 3, scalar (`Long`).** `$.payload.user.id` to a same-length value.
-  *      Measures the splice cost (encode + 3× memcpy) vs the eo-circe AST-modify-then-emit path.
-  *   6. **`.modify` at depth 3, transformation (`*10`).** Same focus; isolates the codec round-trip
-  *      cost (decode + transform + re-encode) on the jsoniter side.
+  * Foci, all on the shared schema + shared codecs ([[fixture.DomainJsoniter]] /
+  * [[fixture.DomainCirce]]):
+  *   - **read `$.id`** (depth-1 `Long`) and **read `$.customer.address.street`** (depth-3 `String`)
+  *     — two depths confirm the byte-walk's advantage doesn't degrade as the focus sinks.
+  *   - **fold `$.lines[*].price`** — array aggregation; a fold must visit every element either way,
+  *     so this is the case where the gap is narrowest.
+  *   - **miss `$.customer.absent`** — eo-jsoniter only. A typed circe codec can't drill a
+  *     non-existent field, so there's no honest circe peer; this row is the byte-walker's own
+  *     hit-vs-miss cost, not a cross-library comparison.
+  *   - **`.replace` / `.modify` `$.id`** — jsoniter splices the byte span; eo-circe modifies the
+  *     AST and re-emits via `noSpaces`.
   *
-  * Each pair compares:
-  *   - `j*` — eo-jsoniter on `Array[Byte]`.
-  *   - `c*` — eo-circe after `circeParse(new String(bytes, "UTF-8"))` to materialise the AST. The
-  *     circe side always starts from `Array[Byte]` to make the comparison fair: parse + drill (or
-  *     parse + modify + emit) is the realistic eo-circe workflow.
-  *
-  * Everything else is deliberately the same: same input bytes, same focus type, same Monoid / same
-  * write target.
-  *
-  * Run:
-  * {{{
-  *   sbt "benchmarks/Jmh/run -i 5 -wi 3 -f 3 .*JsoniterBench.*"
-  * }}}
+  * `@Param size` grows the surrounding document so the parse cost (circe) climbs while the
+  * byte-walk (jsoniter) stays focus-local.
   */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -61,145 +44,47 @@ import hearth.kindlings.circederivation.KindlingsCodecAsObject
 @Measurement(iterations = 5, time = 1)
 class JsoniterBench extends JmhDefaults:
 
-  import JsoniterBench.{*, given}
-  import cats.instances.int.given
-  import cats.instances.list.given
+  import DomainJsoniter.given
+  import cats.instances.double.given
   import cats.instances.long.given
   import cats.instances.string.given
 
-  private val bytes: Array[Byte] = sampleBytes
+  @Param(Array("8", "64", "512"))
+  var size: Int = uninitialized
 
-  // ---- jsoniter-scala-side optics --------------------------------------
+  var bytes: Array[Byte] = uninitialized
 
-  private val jIdLong: Optic[Array[Byte], Array[Byte], Long, Long, Affine] =
-    JsoniterPrism[Long]("$.payload.user.id")
+  @Setup(Level.Iteration)
+  def init(): Unit =
+    bytes = writeToArray(Domain.mkOrder(size))
 
-  private val jEmailString: Optic[Array[Byte], Array[Byte], String, String, Affine] =
-    JsoniterPrism[String]("$.payload.user.profile.email")
+  private def json: Json = circeParse(new String(bytes, "UTF-8")).getOrElse(Json.Null)
 
-  private val jAbsentLong: Optic[Array[Byte], Array[Byte], Long, Long, Affine] =
-    JsoniterPrism[Long]("$.payload.user.absent")
+  // ---- read $.id (depth-1, Long) ------------------------------------
 
-  // ---- eo-circe-side optics --------------------------------------------
+  @Benchmark def jReadId: Long = DomainJsoniter.idPrism.foldMap(identity[Long])(bytes)
+  @Benchmark def cReadId: Long = DomainCirce.idPrism.foldMap(identity[Long])(json)
 
-  private val cIdLong: JsonPrism[Long] =
-    codecPrism[Payload].field(_.user).field(_.id)
+  // ---- read $.customer.address.street (depth-3, String) -------------
 
-  private val cEmailString: JsonPrism[String] =
-    codecPrism[Payload].field(_.user).field(_.profile).field(_.email)
+  @Benchmark def jReadStreet: String = DomainJsoniter.streetPrism.foldMap(identity[String])(bytes)
+  @Benchmark def cReadStreet: String = DomainCirce.streetPrism.foldMap(identity[String])(json)
 
-  // No "absent" eo-circe equivalent because the macro-derived codec
-  // wouldn't include a non-existent field; for the miss case we
-  // measure circe-parse + foldMap on a path that DOES exist but
-  // returns the same scalar — fair-ish comparison.
-  private val cIdLongForMiss: JsonPrism[Long] = cIdLong
+  // ---- fold $.lines[*].price ----------------------------------------
 
-  // ---- benchmarks: hit @ depth 3, Long ---------------------------------
+  @Benchmark def jSumPrices: Double =
+    DomainJsoniter.pricesTraversal.foldMap(identity[Double])(bytes)
 
-  @Benchmark def jHitDepth3Long: Long =
-    jIdLong.foldMap(identity[Long])(bytes)
+  @Benchmark def cSumPrices: Double = DomainCirce.pricesFold.foldMap(identity[Double])(json)
 
-  @Benchmark def cHitDepth3Long: Long =
-    val json = circeParse(new String(bytes, "UTF-8")).getOrElse(Json.Null)
-    cIdLong.foldMap(identity[Long])(json)
+  // ---- miss $.customer.absent (eo-jsoniter only — see scaladoc) -----
 
-  // ---- benchmarks: hit @ depth 4, String -------------------------------
+  @Benchmark def jMiss: Long = DomainJsoniter.absentPrism.foldMap(identity[Long])(bytes)
 
-  @Benchmark def jHitDepth4String: String =
-    jEmailString.foldMap(identity[String])(bytes)
+  // ---- .replace / .modify $.id --------------------------------------
 
-  @Benchmark def cHitDepth4String: String =
-    val json = circeParse(new String(bytes, "UTF-8")).getOrElse(Json.Null)
-    cEmailString.foldMap(identity[String])(json)
+  @Benchmark def jReplaceId: Array[Byte] = DomainJsoniter.idPrism.replace(99L)(bytes)
+  @Benchmark def cReplaceId: String = DomainCirce.idPrism.placeUnsafe(99L)(json).noSpaces
 
-  // ---- benchmarks: miss @ depth 3 --------------------------------------
-
-  @Benchmark def jMissDepth3: Long =
-    jAbsentLong.foldMap(identity[Long])(bytes)
-
-  @Benchmark def cMissDepth3: Long =
-    // The miss bench measures path-walk over an already-decoded AST.
-    // circe's path drill returns Monoid.empty when the field is missing;
-    // we approximate via the same hit path on the circe side
-    // (cIdLongForMiss) since deriving an "absent field" path through a
-    // typed codec isn't natural — this gives circe its best case for
-    // the miss comparison.
-    val json = circeParse(new String(bytes, "UTF-8")).getOrElse(Json.Null)
-    cIdLongForMiss.foldMap(identity[Long])(json)
-
-  // ---- benchmarks: fold over array of 10 Long elements ------------------
-  // Phase-1.5 traversal — sums `$.payload.items[*]`, ten elements,
-  // each a single-digit Long.
-
-  private val jItemsSum: Optic[Array[Byte], Array[Byte], Long, Long, MultiFocus[PSVec]] =
-    JsoniterTraversal[Long]("$.payload.items[*]")
-
-  // eo-circe peer: focus the items array via codecPrism, then traverse it
-  // with the existing Traversal.each over List. This is the realistic
-  // eo-circe shape for "fold over an array field".
-  private val cItemsSum =
-    codecPrism[Payload].field(_.items).andThen(Traversal.each[List, Int])
-
-  @Benchmark def jSumItems: Long =
-    jItemsSum.foldMap(identity[Long])(bytes)
-
-  @Benchmark def cSumItems: Int =
-    val json = circeParse(new String(bytes, "UTF-8")).getOrElse(Json.Null)
-    cItemsSum.foldMap(identity[Int])(json)
-
-  // ---- benchmarks: .replace at depth 3, Long ---------------------------
-  // Phase-2 splice — encode the new value, memcpy three slices into a fresh
-  // Array[Byte]. eo-circe peer modifies the AST and re-emits via printJson.
-
-  @Benchmark def jReplaceLong: Array[Byte] =
-    jIdLong.replace(99L)(bytes)
-
-  @Benchmark def cReplaceLong: String =
-    val json = circeParse(new String(bytes, "UTF-8")).getOrElse(Json.Null)
-    cIdLong.placeUnsafe(99L)(json).noSpaces
-
-  // ---- benchmarks: .modify at depth 3, Long ----------------------------
-  // Same shape but exercises the full codec round-trip on the jsoniter side
-  // (decode + transform + re-encode). The eo-circe side modifies in-AST.
-
-  @Benchmark def jModifyLong: Array[Byte] =
-    jIdLong.modify(_ * 10)(bytes)
-
-  @Benchmark def cModifyLong: String =
-    val json = circeParse(new String(bytes, "UTF-8")).getOrElse(Json.Null)
-    cIdLong.modifyUnsafe(_ * 10)(json).noSpaces
-
-object JsoniterBench:
-
-  // ---- circe codec fixture ---------------------------------------------
-  // eo-circe drills through `codecPrism[Payload].field(_.user).field(_.id)`,
-  // which needs a `Codec.AsObject` for every type along the path.
-
-  final case class Profile(email: String, age: Int)
-
-  object Profile:
-    given Codec.AsObject[Profile] = KindlingsCodecAsObject.derive
-
-  final case class User(id: Long, profile: Profile, name: String)
-
-  object User:
-    given Codec.AsObject[User] = KindlingsCodecAsObject.derive
-
-  final case class Payload(user: User, items: List[Int], tag: String)
-
-  object Payload:
-    given Codec.AsObject[Payload] = KindlingsCodecAsObject.derive
-
-  // ---- jsoniter codec fixture ------------------------------------------
-
-  given JsonValueCodec[Long] = JsonCodecMaker.make
-  given JsonValueCodec[String] = JsonCodecMaker.make
-
-  // ---- shared sample bytes ---------------------------------------------
-
-  /** Synthetic JSON document used by every bench fixture. ~250 bytes — large enough that the
-    * AST-vs-byte-walk gap is observable, small enough that GC doesn't dominate.
-    */
-  val sampleBytes: Array[Byte] =
-    s"""{"payload":{"user":{"id":42,"profile":{"email":"alice@example.com","age":30},"name":"Alice"},"items":[1,2,3,4,5,6,7,8,9,10],"tag":"hot"}}"""
-      .getBytes("UTF-8")
+  @Benchmark def jModifyId: Array[Byte] = DomainJsoniter.idPrism.modify(_ * 10)(bytes)
+  @Benchmark def cModifyId: String = DomainCirce.idPrism.modifyUnsafe(_ * 10)(json).noSpaces

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/MultiFocusBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/MultiFocusBench.scala
@@ -8,13 +8,15 @@ import java.util.concurrent.TimeUnit
 
 import cats.instances.list.*
 
+import dev.constructive.eo.bench.fixture.*
 import dev.constructive.eo.data.MultiFocus
 import dev.constructive.eo.data.MultiFocus.given
 
 /** `MultiFocus[List]` (via `fromLensF`) vs `MultiFocus[PSVec]` (via `Traversal.each[List, _]`) on
-  * the same `Lens[Person, List[Phone]] → inner → Lens[Phone, Boolean]` chain. This isolates the
-  * per-optic-machinery cost of the two carriers on the common "Lens over a List field" traversal
-  * shape; `naive_*` is the hand-rolled `copy` + `List.map` baseline.
+  * the same `Lens[Order, List[LineItem]] → inner → Lens[LineItem, Int]` chain over the canonical
+  * `Order.lines`. This isolates the per-optic-machinery cost of the two carriers on the common
+  * "Lens over a List field" traversal shape; `naive_*` is the hand-rolled `copy` + `List.map`
+  * baseline.
   *
   * The aggregator (`collect*`) and `MultiFocus.tuple` benches that used to share this file now live
   * in [[MultiFocusCollectBench]]; the duplicate ArraySeq PSVec path (identical to
@@ -28,53 +30,42 @@ import dev.constructive.eo.data.MultiFocus.given
 @Measurement(iterations = 5, time = 1)
 class MultiFocusBench extends JmhDefaults:
 
-  import MultiFocusBench.*
-
   @Param(Array("4", "32", "256", "1024"))
   var size: Int = uninitialized
 
-  var person: Person = uninitialized
+  var order: Order = uninitialized
 
-  private val phonesLens =
-    EoLens[Person, List[Phone]](_.phones, (s, b) => s.copy(phones = b))
+  private val linesLens =
+    EoLens[Order, List[LineItem]](_.lines, (o, ls) => o.copy(lines = ls))
 
-  private val isMobileLens =
-    EoLens[Phone, Boolean](_.isMobile, (s, b) => s.copy(isMobile = b))
+  private val qtyLens =
+    EoLens[LineItem, Int](_.qty, (li, q) => li.copy(qty = q))
 
   // Path A: MultiFocus[List] via fromLensF — cardinality-preserving chunking; the
   // tuple2multifocus singleton fast-path fires on the inner Lens.
   private val mfPath =
-    MultiFocus.fromLensF(phonesLens).andThen(isMobileLens)
+    MultiFocus.fromLensF(linesLens).andThen(qtyLens)
 
-  // Path B: PowerSeries via Traversal.each[List, Phone] — specialized
+  // Path B: PowerSeries via Traversal.each[List, LineItem] — specialized
   // PSVec-backed traversal carrier. The chain needs the outer lens
-  // explicitly because Traversal.each[List, Phone] takes `List[Phone]`,
-  // not `Person`.
+  // explicitly because Traversal.each[List, LineItem] takes `List[LineItem]`,
+  // not `Order`.
   private val psPath =
-    phonesLens
-      .andThen(EoTraversal.each[List, Phone])
-      .andThen(isMobileLens)
+    linesLens
+      .andThen(EoTraversal.each[List, LineItem])
+      .andThen(qtyLens)
 
   @Setup(Level.Iteration)
   def init(): Unit =
-    person = Person(
-      "Alice",
-      List.tabulate(size)(i => Phone(isMobile = i % 2 == 0, s"n-$i")),
+    order = Domain.mkOrder(size)
+
+  @Benchmark def eoModify_multiFocus: Order =
+    mfPath.modify(_ + 1)(order)
+
+  @Benchmark def eoModify_powerEach: Order =
+    psPath.modify(_ + 1)(order)
+
+  @Benchmark def naive_listMap: Order =
+    order.copy(
+      lines = order.lines.map(li => li.copy(qty = li.qty + 1))
     )
-
-  @Benchmark def eoModify_multiFocus: Person =
-    mfPath.modify(!_)(person)
-
-  @Benchmark def eoModify_powerEach: Person =
-    psPath.modify(!_)(person)
-
-  @Benchmark def naive_listMap: Person =
-    person.copy(
-      phones = person.phones.map(ph => ph.copy(isMobile = !ph.isMobile))
-    )
-
-object MultiFocusBench:
-
-  case class Phone(isMobile: Boolean, number: String)
-
-  case class Person(name: String, phones: List[Phone])

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/OpticBuildBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/OpticBuildBench.scala
@@ -33,18 +33,23 @@ import io.circe.syntax.*
 @Measurement(iterations = 5, time = 1)
 class OpticBuildBench extends JmhDefaults:
 
-  import OrderCirceBench.given
+  import DomainCirce.given
 
   private val json: Json = Domain.mkOrder(16).asJson
 
-  private val prebuilt: JsonPrism[String] =
-    codecPrism[Order].field(_.customer).field(_.address).field(_.street)
+  // `build` / `buildAndUse` construct the prism inline (that's what they measure);
+  // `reuseUse` runs through the shared pre-built `DomainCirce.streetPrism`.
+  private val prebuilt: JsonPrism[String] = DomainCirce.streetPrism
 
   @Benchmark def build: Any =
     codecPrism[Order].field(_.customer).field(_.address).field(_.street)
 
   @Benchmark def buildAndUse: Json =
-    codecPrism[Order].field(_.customer).field(_.address).field(_.street).modifyUnsafe(_.toUpperCase)(json)
+    codecPrism[Order]
+      .field(_.customer)
+      .field(_.address)
+      .field(_.street)
+      .modifyUnsafe(_.toUpperCase)(json)
 
   @Benchmark def reuseUse: Json =
     prebuilt.modifyUnsafe(_.toUpperCase)(json)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/OpticsBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/OpticsBench.scala
@@ -6,6 +6,7 @@ import scala.compiletime.uninitialized
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
 
+import dev.constructive.eo.bench.fixture.*
 import dev.constructive.eo.optics.{
   Iso => EoIso,
   Lens => EoLens,
@@ -20,13 +21,14 @@ import cats.instances.list.given
 
 import monocle.{Iso => MIso, Lens => MLens, Prism => MPrism, Traversal => MTraversal}
 
-/** Shared sample data used across benchmarks. */
-final case class Person(age: Int, name: String)
-
-/** Lens.get / Lens.replace / Lens.modify
+/** Lens.get / Lens.replace / Lens.modify on the canonical [[Order]], paired EO vs Monocle.
   *
-  * Both Monocle's `Lens` and EO's `Optic[..., Tuple2]` implement the lens algebra; this benchmark
-  * compares the per-call overhead of each surface for the canonical `Person.age` case.
+  * Two foci on the one fixture:
+  *   - **shallow scalar** `order.id: Long` — the bare per-call lens-algebra overhead (the
+  *     surrounding `lines` list is shared by reference, so `replace`/`modify` is a single-record
+  *     copy).
+  *   - **depth-3 path** `customer.address.street: String` — the nested-copy cost both libraries pay
+  *     for a deep write (three records rebuilt, `lines` still shared).
   */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -36,22 +38,35 @@ final case class Person(age: Int, name: String)
 @Measurement(iterations = 5, time = 1)
 class LensBench extends JmhDefaults:
 
-  val person: Person = Person(30, "Alice")
+  val order: Order = Domain.mkOrder(8)
 
-  val eoAge =
-    EoLens[Person, Int](_.age, (p, a) => p.copy(age = a))
+  // ---- shallow: order.id --------------------------------------------
 
-  val mAge: MLens[Person, Int] =
-    MLens[Person, Int](_.age)(a => p => p.copy(age = a))
+  val eoId =
+    EoLens[Order, Long](_.id, (o, v) => o.copy(id = v))
 
-  @Benchmark def eoGet: Int = eoAge.get(person)
-  @Benchmark def mGet: Int = mAge.get(person)
+  val mId: MLens[Order, Long] =
+    MLens[Order, Long](_.id)(v => o => o.copy(id = v))
 
-  @Benchmark def eoReplace: Person = eoAge.replace(40)(person)
-  @Benchmark def mReplace: Person = mAge.replace(40)(person)
+  @Benchmark def eoGet: Long = eoId.get(order)
+  @Benchmark def mGet: Long = mId.get(order)
 
-  @Benchmark def eoModify: Person = eoAge.modify(_ + 1)(person)
-  @Benchmark def mModify: Person = mAge.modify(_ + 1)(person)
+  @Benchmark def eoReplace: Order = eoId.replace(99L)(order)
+  @Benchmark def mReplace: Order = mId.replace(99L)(order)
+
+  @Benchmark def eoModify: Order = eoId.modify(_ + 1)(order)
+  @Benchmark def mModify: Order = mId.modify(_ + 1)(order)
+
+  // ---- deep: customer.address.street (Monocle peer = DomainMonocle.street) ----
+
+  val eoStreet =
+    EoLens[Order, String](
+      _.customer.address.street,
+      (o, s) => o.copy(customer = o.customer.copy(address = o.customer.address.copy(street = s))),
+    )
+
+  @Benchmark def eoModifyDeep: Order = eoStreet.modify(_.toUpperCase)(order)
+  @Benchmark def mModifyDeep: Order = DomainMonocle.street.modify(_.toUpperCase)(order)
 
 /** Prism.getOption / Prism.reverseGet
   *
@@ -59,6 +74,10 @@ class LensBench extends JmhDefaults:
   *   - `optional`-style prism on `Option[Int]` (Some / None).
   *   - `Either[String, Int]` prism focusing the Right (Int) branch; this is a more natural Prism
   *     since the residual type differs from the focused type.
+  *
+  * These exercise the Prism algebra over the stdlib `Option`/`Either` carriers directly, so there's
+  * no domain fixture to share — the sum-type-over-a-domain-ADT story lives in
+  * [[PowerSeriesPrismBench]] and [[GenericsBench]].
   */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -109,11 +128,11 @@ class PrismBench extends JmhDefaults:
   @Benchmark def eoRightReverseGet: Either[String, Int] = eoRight.reverseGet(raw)
   @Benchmark def mRightReverseGet: Either[String, Int] = mRight.reverseGet(raw)
 
-/** Iso.get / Iso.reverseGet on `(Int, String) <-> Person(age, name)`.
+/** Iso.get / Iso.reverseGet on `Address <-> (String, String, String, String)`.
   *
-  * A product-to-product isomorphism is a more honest benchmark than a primitive conversion: every
-  * call allocates a new carrier on each side and exercises the same boxing behaviour a real Iso
-  * would.
+  * A product-to-product isomorphism over the canonical [[Address]] is a more honest benchmark than
+  * a primitive conversion: every call allocates a new carrier on each side and exercises the same
+  * boxing behaviour a real Iso would.
   */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -123,31 +142,37 @@ class PrismBench extends JmhDefaults:
 @Measurement(iterations = 5, time = 1)
 class IsoBench extends JmhDefaults:
 
-  val tuple: (Int, String) = (30, "Alice")
-  val person: Person = Person(30, "Alice")
+  val address: Address = Domain.DefaultCustomer.address
+
+  val tuple: (String, String, String, String) =
+    (address.street, address.city, address.zip, address.country)
 
   // No explicit type annotation: let inference pick BijectionIso, the
   // concrete EO subclass that stores get / reverseGet directly and
   // skips the Accessor[Direct] / ReverseAccessor[Direct] dispatch.
   val eoIso =
-    EoIso[(Int, String), (Int, String), Person, Person](
-      t => Person(t._1, t._2),
-      p => (p.age, p.name),
+    EoIso[(String, String, String, String), (String, String, String, String), Address, Address](
+      t => Address(t._1, t._2, t._3, t._4),
+      a => (a.street, a.city, a.zip, a.country),
     )
 
-  val mIso: MIso[(Int, String), Person] =
-    MIso[(Int, String), Person](t => Person(t._1, t._2))(p => (p.age, p.name))
+  val mIso: MIso[(String, String, String, String), Address] =
+    MIso[(String, String, String, String), Address](t => Address(t._1, t._2, t._3, t._4))(a =>
+      (a.street, a.city, a.zip, a.country)
+    )
 
-  @Benchmark def eoGet: Person = eoIso.get(tuple)
-  @Benchmark def mGet: Person = mIso.get(tuple)
+  @Benchmark def eoGet: Address = eoIso.get(tuple)
+  @Benchmark def mGet: Address = mIso.get(tuple)
 
-  @Benchmark def eoReverseGet: (Int, String) = eoIso.reverseGet(person)
-  @Benchmark def mReverseGet: (Int, String) = mIso.reverseGet(person)
+  @Benchmark def eoReverseGet: (String, String, String, String) = eoIso.reverseGet(address)
+  @Benchmark def mReverseGet: (String, String, String, String) = mIso.reverseGet(address)
 
-/** Traversal.modify over a moderately sized List[Int].
+/** Traversal.modify over the canonical `Order.lines` (a `List[LineItem]`).
   *
   * The Monocle traversal walks the list with a Traverse[List]; the EO traversal walks via the
-  * MultiFocus[PSVec] carrier (Functor[PSVec].map after collecting into the focus vector).
+  * MultiFocus[PSVec] carrier (Functor[PSVec].map after collecting into the focus vector). Modify
+  * bumps every line's `qty` — a bare `each` over the canonical element type, so the row reads
+  * apples-to-apples against the integration benches' `lines[*]` traversals.
   */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -160,17 +185,17 @@ class TraversalBench extends JmhDefaults:
   @Param(Array("8", "64", "512"))
   var size: Int = uninitialized
 
-  var xs: List[Int] = uninitialized
+  var lines: List[LineItem] = uninitialized
 
-  val eoEach: Optic[List[Int], List[Int], Int, Int, MultiFocus[PSVec]] =
-    EoTraversal.each[List, Int]
+  val eoEach: Optic[List[LineItem], List[LineItem], LineItem, LineItem, MultiFocus[PSVec]] =
+    EoTraversal.each[List, LineItem]
 
-  val mEach: MTraversal[List[Int], Int] =
-    MTraversal.fromTraverse[List, Int]
+  val mEach: MTraversal[List[LineItem], LineItem] =
+    MTraversal.fromTraverse[List, LineItem]
 
   @Setup(Level.Iteration)
   def init(): Unit =
-    xs = List.tabulate(size)(identity)
+    lines = Domain.mkOrder(size).lines
 
-  @Benchmark def eoModify: List[Int] = eoEach.modify(_ + 1)(xs)
-  @Benchmark def mModify: List[Int] = mEach.modify(_ + 1)(xs)
+  @Benchmark def eoModify: List[LineItem] = eoEach.modify(li => li.copy(qty = li.qty + 1))(lines)
+  @Benchmark def mModify: List[LineItem] = mEach.modify(li => li.copy(qty = li.qty + 1))(lines)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/OptionalBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/OptionalBench.scala
@@ -43,6 +43,20 @@ class OptionalBench extends JmhDefaults:
     mOpt3,
     mOpt6,
   }
+  import DomainOptics.{eoLoyalty, mLoyalty, order, orderNoLoyalty}
+
+  // ---- canonical focus: customer.loyaltyId (Option[String]) ---------
+  // The advertised Optional focus, in memory (avro omits it — union, not a
+  // transparent field). Some-branch on `order`, None-branch on `orderNoLoyalty`.
+
+  @Benchmark def eoModify_loyalty: Order = eoLoyalty.modify(_.toUpperCase)(order)
+  @Benchmark def mModify_loyalty: Order = mLoyalty.modify(_.toUpperCase)(order)
+
+  @Benchmark def eoModify_loyalty_empty: Order = eoLoyalty.modify(_.toUpperCase)(orderNoLoyalty)
+  @Benchmark def mModify_loyalty_empty: Order = mLoyalty.modify(_.toUpperCase)(orderNoLoyalty)
+
+  @Benchmark def eoReplace_loyalty: Order = eoLoyalty.replace("LOYAL-999")(order)
+  @Benchmark def mReplace_loyalty: Order = mLoyalty.replace("LOYAL-999")(order)
 
   // ---- Composed EO optionals — Lens chain composed directly with the
   //      leaf Optional via cross-carrier `.andThen`. The Monocle peer

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/OrderAvroBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/OrderAvroBench.scala
@@ -6,10 +6,8 @@ import scala.compiletime.uninitialized
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
 
-import dev.constructive.eo.avro.{AvroCodec, codecPrism}
 import dev.constructive.eo.bench.fixture.*
 
-import hearth.kindlings.avroderivation.{AvroDecoder, AvroEncoder, AvroSchemaFor}
 import org.apache.avro.generic.IndexedRecord
 
 /** Canonical-schema avro bench (plan 009, Phase 1).
@@ -40,15 +38,10 @@ import org.apache.avro.generic.IndexedRecord
 @Measurement(iterations = 5, time = 1)
 class OrderAvroBench extends JmhDefaults:
 
-  import OrderAvroBench.given
+  import DomainAvro.{codec, namesTraversal, streetPrism}
 
   @Param(Array("8", "64", "512"))
   var size: Int = uninitialized
-
-  private val codec = summon[AvroCodec[Order]]
-
-  private val streetPrism = codecPrism[Order].field(_.customer).field(_.address).field(_.street)
-  private val namesTraversal = codecPrism[Order].lines.each.name
 
   var record: IndexedRecord = uninitialized
 
@@ -101,21 +94,3 @@ class OrderAvroBench extends JmhDefaults:
   @Benchmark def monocleModifyNames: IndexedRecord =
     val o = codec.decodeEither(record).toOption.get
     codec.encode(DomainMonocle.names.modify(_.toUpperCase)(o)).asInstanceOf[IndexedRecord]
-
-object OrderAvroBench:
-
-  given AvroEncoder[Address] = AvroEncoder.derived
-  given AvroDecoder[Address] = AvroDecoder.derived
-  given AvroSchemaFor[Address] = AvroSchemaFor.derived
-
-  given AvroEncoder[Customer] = AvroEncoder.derived
-  given AvroDecoder[Customer] = AvroDecoder.derived
-  given AvroSchemaFor[Customer] = AvroSchemaFor.derived
-
-  given AvroEncoder[LineItem] = AvroEncoder.derived
-  given AvroDecoder[LineItem] = AvroDecoder.derived
-  given AvroSchemaFor[LineItem] = AvroSchemaFor.derived
-
-  given AvroEncoder[Order] = AvroEncoder.derived
-  given AvroDecoder[Order] = AvroDecoder.derived
-  given AvroSchemaFor[Order] = AvroSchemaFor.derived

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/OrderCirceBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/OrderCirceBench.scala
@@ -7,14 +7,12 @@ import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
 
 import dev.constructive.eo.bench.fixture.*
-import dev.constructive.eo.circe.{JsonFailure, JsonPrism, codecPrism}
+import dev.constructive.eo.circe.JsonFailure
 
 import cats.data.{Chain, Ior}
 
-import io.circe.{Codec, Json}
+import io.circe.Json
 import io.circe.syntax.*
-
-import hearth.kindlings.circederivation.KindlingsCodecAsObject
 
 /** Canonical-schema circe bench (plan 009, Phase 1 proof-of-concept).
   *
@@ -47,7 +45,7 @@ import hearth.kindlings.circederivation.KindlingsCodecAsObject
 @Measurement(iterations = 5, time = 1)
 class OrderCirceBench extends JmhDefaults:
 
-  import OrderCirceBench.{*, given}
+  import DomainCirce.{namesTraversal, namesTraversalIor, streetPrism, given}
 
   @Param(Array("8", "64", "512"))
   var size: Int = uninitialized
@@ -163,28 +161,3 @@ class OrderCirceBench extends JmhDefaults:
   @Benchmark def monocleNames: Json =
     val o = json.as[Order].toOption.get
     DomainMonocle.names.modify(_.toUpperCase)(o).asJson
-
-object OrderCirceBench:
-
-  // ---- circe codecs for the canonical schema ------------------------
-
-  given Codec.AsObject[Address] = KindlingsCodecAsObject.derive
-  given Codec.AsObject[Customer] = KindlingsCodecAsObject.derive
-  given Codec.AsObject[LineItem] = KindlingsCodecAsObject.derive
-  given Codec.AsObject[Order] = KindlingsCodecAsObject.derive
-
-  // ---- EO circe optics ----------------------------------------------
-
-  val streetPrism: JsonPrism[String] =
-    codecPrism[Order].field(_.customer).field(_.address).field(_.street)
-
-  // `lines[*].name` traversal — same proven selectDynamic chain as the
-  // legacy Basket bench. Pre-built into the `Json => …` function so the
-  // bench loop measures only the rewrite.
-  val namesTraversal: Json => Json =
-    codecPrism[Order].lines.each.name.modifyUnsafe(_.toUpperCase)
-
-  val namesTraversalIor: Json => Ior[Chain[JsonFailure], Json] =
-    codecPrism[Order].lines.each.name.modify(_.toUpperCase)
-
-  // Monocle peers live on the shared `DomainMonocle` fixture.

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/OrderJsoniterBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/OrderJsoniterBench.scala
@@ -6,20 +6,10 @@ import scala.compiletime.uninitialized
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
 
-import com.github.plokhotnyuk.jsoniter_scala.core.{
-  JsonReader,
-  JsonValueCodec,
-  JsonWriter,
-  readFromArray,
-  writeToArray,
-}
-import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import com.github.plokhotnyuk.jsoniter_scala.core.{readFromArray, writeToArray}
 
 import dev.constructive.eo.bench.fixture.*
-import dev.constructive.eo.data.{Affine, MultiFocus, PSVec}
 import dev.constructive.eo.data.MultiFocus.given
-import dev.constructive.eo.jsoniter.{JsoniterPrism, JsoniterTraversal}
-import dev.constructive.eo.optics.Optic
 
 /** Canonical-schema jsoniter bench (plan 009, Phase 1).
   *
@@ -53,7 +43,7 @@ import dev.constructive.eo.optics.Optic
 @Measurement(iterations = 5, time = 1)
 class OrderJsoniterBench extends JmhDefaults:
 
-  import OrderJsoniterBench.{pricesSumScanCodec, streetScanCodec, given}
+  import DomainJsoniter.{pricesSumScanCodec, pricesTraversal, streetPrism, streetScanCodec, given}
   import cats.instances.double.given
   import cats.instances.string.given
 
@@ -61,12 +51,6 @@ class OrderJsoniterBench extends JmhDefaults:
   var size: Int = uninitialized
 
   var bytes: Array[Byte] = uninitialized
-
-  private val eoStreetP: Optic[Array[Byte], Array[Byte], String, String, Affine] =
-    JsoniterPrism[String]("$.customer.address.street")
-
-  private val eoPricesT: Optic[Array[Byte], Array[Byte], Double, Double, MultiFocus[PSVec]] =
-    JsoniterTraversal[Double]("$.lines[*].price")
 
   @Setup(Level.Iteration)
   def init(): Unit =
@@ -95,7 +79,7 @@ class OrderJsoniterBench extends JmhDefaults:
   // ---- read scalar: $.customer.address.street -----------------------
 
   @Benchmark def eoReadStreet: String =
-    eoStreetP.foldMap(identity[String])(bytes)
+    streetPrism.foldMap(identity[String])(bytes)
 
   // The optimum native read: a hand-rolled JsonReader that walks to the focus
   // and `skip()`s every other field — the whole object is *not* materialised.
@@ -114,7 +98,7 @@ class OrderJsoniterBench extends JmhDefaults:
   // ---- write scalar: $.customer.address.street ----------------------
 
   @Benchmark def eoModifyStreet: Array[Byte] =
-    eoStreetP.modify(_.toUpperCase)(bytes)
+    streetPrism.modify(_.toUpperCase)(bytes)
 
   // Naive write: full decode → copy → re-encode. (A native partial-splice
   // write is what eo-jsoniter's `.modify` already does — there's no simpler
@@ -134,7 +118,7 @@ class OrderJsoniterBench extends JmhDefaults:
   // ---- fold array: $.lines[*].price ---------------------------------
 
   @Benchmark def eoSumPrices: Double =
-    eoPricesT.foldMap(identity[Double])(bytes)
+    pricesTraversal.foldMap(identity[Double])(bytes)
 
   // The optimum native fold: walk to `lines`, sum each element's `price`,
   // skip()ing every sibling field at both levels — the line objects are never
@@ -148,68 +132,3 @@ class OrderJsoniterBench extends JmhDefaults:
 
   @Benchmark def monocleSumPrices: Double =
     DomainMonocle.prices.getAll(readFromArray[Order](bytes)).sum
-
-object OrderJsoniterBench:
-
-  // Whole-document codec for the naive / monocle round-trip baselines.
-  given JsonValueCodec[Order] = JsonCodecMaker.make
-
-  // Leaf codecs the JsoniterPrism / JsoniterTraversal foci decode through.
-  given JsonValueCodec[String] = JsonCodecMaker.make
-
-  /** Read the value of `target` inside the current JSON object, skipping every other field, then
-    * return `inner` applied to the reader positioned at that value. Returns `default` if the object
-    * / field is absent.
-    */
-  private def field[A](in: JsonReader, target: String, default: A)(inner: JsonReader => A): A =
-    if in.isNextToken('{') then
-      var result = default
-      if !in.isNextToken('}') then
-        in.rollbackToken()
-        while
-          if in.readKeyAsString() == target then result = inner(in)
-          else in.skip()
-          in.isNextToken(',')
-        do ()
-      result
-    else
-      in.rollbackToken()
-      in.skip()
-      default
-
-  /** Hand-rolled scanner for `$.customer.address.street` — walks only the path and `skip()`s
-    * siblings, so the full `Order` is never materialised. A plain `val` (not `given`) so it doesn't
-    * collide with the derived `JsonValueCodec[String]`; passed explicitly to `readFromArray`.
-    */
-  val streetScanCodec: JsonValueCodec[String] = new JsonValueCodec[String]:
-    def nullValue: String = null
-    def encodeValue(x: String, out: JsonWriter): Unit = out.writeVal(x)
-    def decodeValue(in: JsonReader, default: String): String =
-      field(in, "customer", default) { in =>
-        field(in, "address", default) { in =>
-          field(in, "street", default)(_.readString(null))
-        }
-      }
-
-  /** Hand-rolled scanner for `$.lines[*].price` — walks to the `lines` array, sums each element's
-    * `price`, and `skip()`s every sibling at both levels. The line objects are never fully
-    * materialised.
-    */
-  val pricesSumScanCodec: JsonValueCodec[Double] = new JsonValueCodec[Double]:
-    def nullValue: Double = 0.0
-    def encodeValue(x: Double, out: JsonWriter): Unit = out.writeVal(x)
-    def decodeValue(in: JsonReader, default: Double): Double =
-      field(in, "lines", default) { in =>
-        var sum = 0.0
-        if in.isNextToken('[') then
-          if !in.isNextToken(']') then
-            in.rollbackToken()
-            while
-              sum += field(in, "price", 0.0)(_.readDouble())
-              in.isNextToken(',')
-            do ()
-        else in.rollbackToken()
-        sum
-      }
-
-  given JsonValueCodec[Double] = JsonCodecMaker.make

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesBench.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit
 
 import cats.instances.arraySeq.*
 
+import dev.constructive.eo.bench.fixture.{Person, Phone}
 import dev.constructive.eo.data.MultiFocus.given
 
 /** PowerSeries-backed Traversal over a nested focus, paired against a hand-written iterative
@@ -33,8 +34,6 @@ import dev.constructive.eo.data.MultiFocus.given
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 class PowerSeriesBench extends JmhDefaults:
-
-  import PowerSeriesBench.*
 
   @Param(Array("4", "32", "256", "1024"))
   var size: Int = uninitialized
@@ -63,9 +62,3 @@ class PowerSeriesBench extends JmhDefaults:
     person.copy(
       phones = person.phones.map(ph => ph.copy(isMobile = !ph.isMobile))
     )
-
-object PowerSeriesBench:
-
-  case class Phone(isMobile: Boolean, number: String)
-
-  case class Person(name: String, phones: ArraySeq[Phone])

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesNestedBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesNestedBench.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit
 import cats.instances.arraySeq.given
 import cats.instances.list.given
 
+import dev.constructive.eo.bench.fixture.{Company, Department, Employee}
 import dev.constructive.eo.data.MultiFocus.given
 
 /** Nested-traversal PowerSeries bench — tree-of-trees shape.
@@ -41,8 +42,6 @@ import dev.constructive.eo.data.MultiFocus.given
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 class PowerSeriesNestedBench extends JmhDefaults:
-
-  import PowerSeriesNestedBench.*
 
   @Param(Array("4", "32", "256"))
   var size: Int = uninitialized
@@ -84,9 +83,3 @@ class PowerSeriesNestedBench extends JmhDefaults:
         .departments
         .map(d => d.copy(employees = d.employees.map(e => e.copy(active = !e.active))))
     )
-
-object PowerSeriesNestedBench:
-
-  case class Employee(id: Int, name: String, active: Boolean)
-  case class Department(name: String, employees: ArraySeq[Employee])
-  case class Company(name: String, departments: List[Department])

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesPrismBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesPrismBench.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit
 
 import cats.instances.arraySeq.given
 
+import dev.constructive.eo.bench.fixture.Result
 import dev.constructive.eo.data.MultiFocus.given
 
 /** Sparse-Prism PowerSeries bench — half-hit, half-miss per element through a Prism sitting after a
@@ -33,8 +34,6 @@ import dev.constructive.eo.data.MultiFocus.given
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 class PowerSeriesPrismBench extends JmhDefaults:
-
-  import PowerSeriesPrismBench.*
 
   @Param(Array("8", "64", "512"))
   var size: Int = uninitialized
@@ -67,9 +66,3 @@ class PowerSeriesPrismBench extends JmhDefaults:
       case Result.Ok(v) => Result.Ok(v + 1)
       case other        => other
     }
-
-object PowerSeriesPrismBench:
-
-  enum Result:
-    case Ok(value: Int)
-    case Err(msg: String)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/SetterBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/SetterBench.scala
@@ -6,13 +6,14 @@ import java.util.concurrent.TimeUnit
 
 import dev.constructive.eo.bench.fixture.*
 
-/** `Setter.modify` at the leaf plus deep manual composition, paired EO vs Monocle.
+/** `Setter.modify` at the leaf plus deep composition, paired EO vs Monocle.
   *
-  * '''Scope note.''' EO's `Setter` carrier is `SetterF`, which has a `ForgetfulFunctor[SetterF]`
-  * instance but no `AssociativeFunctor[SetterF, X, Y]` instance — so two Setters cannot be composed
-  * via `Optic.andThen`. For depth-3 / depth-6 writes the bench nests `modify` calls — each outer
-  * Setter modifies the next `n`, with the innermost modifying the leaf's `value`. Monocle's
-  * first-class `Setter.andThen` produces the equivalent composed Setter on its side.
+  * EO's `Setter` carrier `SetterF` has both a `ForgetfulFunctor[SetterF]` (powers `.modify`) and an
+  * `AssociativeFunctor[SetterF]` (`assocSetterF`), so two Setters compose through the ordinary
+  * `andThen` — `s1.andThen(s2).modify(f) == s1.modify(s2.modify(f))`. The depth-3 / depth-6 rows
+  * build a *composed* `Setter` on both sides (EO's `s3.andThen(s2)…` vs Monocle's
+  * `mS3.andThen(mS2)…`) and dispatch through it once, rather than hand-nesting `modify` on the EO
+  * side.
   */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -46,29 +47,17 @@ class SetterBench extends JmhDefaults:
 
   // ---- Nested depth sweep (composition, which Order can't express) --
 
+  // Both sides build a composed Setter and dispatch through it once.
+  private val eoSet3 = eoS3.andThen(eoS2).andThen(eoS1).andThen(eoSetValue)
+
+  private val eoSet6 =
+    eoS6.andThen(eoS5).andThen(eoS4).andThen(eoS3).andThen(eoS2).andThen(eoS1).andThen(eoSetValue)
+
   @Benchmark def eoModify_0: Nested0 = eoSetValue.modify(_ + 1)(leaf)
   @Benchmark def mModify_0: Nested0 = mSetValue.modify(_ + 1)(leaf)
 
-  @Benchmark def eoModify_3: Nested3 =
-    eoS3.modify(
-      eoS2.modify(
-        eoS1.modify(eoSetValue.modify(_ + 1))
-      )
-    )(d3)
-
+  @Benchmark def eoModify_3: Nested3 = eoSet3.modify(_ + 1)(d3)
   @Benchmark def mModify_3: Nested3 = mSet3.modify(_ + 1)(d3)
 
-  @Benchmark def eoModify_6: Nested6 =
-    eoS6.modify(
-      eoS5.modify(
-        eoS4.modify(
-          eoS3.modify(
-            eoS2.modify(
-              eoS1.modify(eoSetValue.modify(_ + 1))
-            )
-          )
-        )
-      )
-    )(d6)
-
+  @Benchmark def eoModify_6: Nested6 = eoSet6.modify(_ + 1)(d6)
   @Benchmark def mModify_6: Nested6 = mSet6.modify(_ + 1)(d6)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/SetterBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/SetterBench.scala
@@ -37,6 +37,14 @@ class SetterBench extends JmhDefaults:
     mSet6,
     mSetValue,
   }
+  import DomainOptics.{eoSetId, mSetId, order}
+
+  // ---- canonical scalar focus: order.id ($.id) ----------------------
+
+  @Benchmark def eoModify_orderId: Order = eoSetId.modify(_ + 1)(order)
+  @Benchmark def mModify_orderId: Order = mSetId.modify(_ + 1)(order)
+
+  // ---- Nested depth sweep (composition, which Order can't express) --
 
   @Benchmark def eoModify_0: Nested0 = eoSetValue.modify(_ + 1)(leaf)
   @Benchmark def mModify_0: Nested0 = mSetValue.modify(_ + 1)(leaf)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/DomainAvro.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/DomainAvro.scala
@@ -1,0 +1,42 @@
+package dev.constructive.eo
+package bench
+package fixture
+
+import dev.constructive.eo.avro.{AvroCodec, codecPrism}
+
+import hearth.kindlings.avroderivation.{AvroDecoder, AvroEncoder, AvroSchemaFor}
+
+/** Avro `Encoder`/`Decoder`/`SchemaFor` instances and EO avro optics for the canonical [[Order]]
+  * schema, shared by `OrderAvroBench`.
+  *
+  * `customer.loyaltyId` is intentionally not focused: kindlings encodes `Option` as an Avro union
+  * navigated via `.union[Branch]`, not a transparent field, so it isn't a clean cross-backend peer
+  * (plan 009, Avro `Option` caveat).
+  */
+object DomainAvro:
+
+  given AvroEncoder[Address] = AvroEncoder.derived
+  given AvroDecoder[Address] = AvroDecoder.derived
+  given AvroSchemaFor[Address] = AvroSchemaFor.derived
+
+  given AvroEncoder[Customer] = AvroEncoder.derived
+  given AvroDecoder[Customer] = AvroDecoder.derived
+  given AvroSchemaFor[Customer] = AvroSchemaFor.derived
+
+  given AvroEncoder[LineItem] = AvroEncoder.derived
+  given AvroDecoder[LineItem] = AvroDecoder.derived
+  given AvroSchemaFor[LineItem] = AvroSchemaFor.derived
+
+  given AvroEncoder[Order] = AvroEncoder.derived
+  given AvroDecoder[Order] = AvroDecoder.derived
+  given AvroSchemaFor[Order] = AvroSchemaFor.derived
+
+  /** The whole-document codec the `naive*` / `monocle*` round-trip baselines decode/encode through.
+    */
+  val codec: AvroCodec[Order] = summon[AvroCodec[Order]]
+
+  /** depth-3 scalar `customer.address.street`. */
+  val streetPrism = codecPrism[Order].field(_.customer).field(_.address).field(_.street)
+
+  /** array write traversal `lines[*].name`. */
+  val namesTraversal = codecPrism[Order].lines.each.name

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/DomainCirce.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/DomainCirce.scala
@@ -1,0 +1,58 @@
+package dev.constructive.eo
+package bench
+package fixture
+
+import dev.constructive.eo.circe.{JsonFailure, JsonPrism, codecPrism}
+import dev.constructive.eo.data.MultiFocus.given
+import dev.constructive.eo.optics.{Lens => EoLens, Traversal => EoTraversal}
+
+import cats.data.{Chain, Ior}
+import cats.instances.list.given
+
+import io.circe.{Codec, Json}
+
+import hearth.kindlings.circederivation.KindlingsCodecAsObject
+
+/** circe `Codec.AsObject` instances and EO circe optics for the canonical [[Order]] schema, shared
+  * by every circe-flavoured bench (`OrderCirceBench`, `OpticBuildBench`, the eo-circe side of
+  * `JsoniterBench`).
+  *
+  * Centralised here — rather than re-derived in each bench companion — so the codecs and the foci
+  * are defined exactly once and every bench measures the *same* optic against the *same* document.
+  */
+object DomainCirce:
+
+  // ---- codecs (every type on every focus path) ----------------------
+
+  given Codec.AsObject[Address] = KindlingsCodecAsObject.derive
+  given Codec.AsObject[Customer] = KindlingsCodecAsObject.derive
+  given Codec.AsObject[LineItem] = KindlingsCodecAsObject.derive
+  given Codec.AsObject[Order] = KindlingsCodecAsObject.derive
+
+  // ---- EO circe optics ----------------------------------------------
+
+  /** depth-1 scalar `$.id` (`Long`). */
+  val idPrism: JsonPrism[Long] = codecPrism[Order].field(_.id)
+
+  /** depth-3 scalar `$.customer.address.street` (`String`). */
+  val streetPrism: JsonPrism[String] =
+    codecPrism[Order].field(_.customer).field(_.address).field(_.street)
+
+  /** array fold focus `$.lines[*].price` (`Double`) — read side for the cross-EO fold comparison.
+    * Built through the core `Traversal.each` (not circe's `Dynamic` `.each`) so it carries a real
+    * `foldMap`.
+    */
+  val pricesFold =
+    codecPrism[Order]
+      .field(_.lines)
+      .andThen(EoTraversal.each[List, LineItem])
+      .andThen(EoLens[LineItem, Double](_.price, (li, p) => li.copy(price = p)))
+
+  /** `lines[*].name` write traversal, pre-built into the `Json => …` rewrite so the bench loop
+    * measures only the modify.
+    */
+  val namesTraversal: Json => Json =
+    codecPrism[Order].lines.each.name.modifyUnsafe(_.toUpperCase)
+
+  val namesTraversalIor: Json => Ior[Chain[JsonFailure], Json] =
+    codecPrism[Order].lines.each.name.modify(_.toUpperCase)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/DomainJsoniter.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/DomainJsoniter.scala
@@ -1,0 +1,102 @@
+package dev.constructive.eo
+package bench
+package fixture
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonValueCodec, JsonWriter}
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+import dev.constructive.eo.data.{Affine, MultiFocus, PSVec}
+import dev.constructive.eo.jsoniter.{JsoniterPrism, JsoniterTraversal}
+import dev.constructive.eo.optics.Optic
+
+/** jsoniter-scala codecs, EO jsoniter optics, and hand-rolled partial-scan codecs for the canonical
+  * [[Order]] schema, shared by `OrderJsoniterBench` and the eo-jsoniter side of `JsoniterBench`.
+  *
+  * The hand-rolled scanners ([[streetScanCodec]] / [[pricesSumScanCodec]]) walk to a focus and
+  * `skip()` every sibling — the optimum a jsoniter expert would write by hand, and exactly what
+  * eo-jsoniter does generically. Their agreement with a full decode is asserted in each bench's
+  * `@Setup` (JMH never checks return values, so that `require` is the only honesty guard).
+  */
+object DomainJsoniter:
+
+  // ---- whole-document + leaf codecs ---------------------------------
+
+  given JsonValueCodec[Order] = JsonCodecMaker.make
+  given JsonValueCodec[Long] = JsonCodecMaker.make
+  given JsonValueCodec[String] = JsonCodecMaker.make
+  given JsonValueCodec[Double] = JsonCodecMaker.make
+
+  // ---- EO jsoniter optics (JSONPath) --------------------------------
+
+  /** depth-1 scalar `$.id` (`Long`) — read / replace / modify vehicle. */
+  val idPrism: Optic[Array[Byte], Array[Byte], Long, Long, Affine] =
+    JsoniterPrism[Long]("$.id")
+
+  /** depth-3 scalar `$.customer.address.street` (`String`). */
+  val streetPrism: Optic[Array[Byte], Array[Byte], String, String, Affine] =
+    JsoniterPrism[String]("$.customer.address.street")
+
+  /** a deliberately-absent path `$.customer.absent` — the honest "miss" stress test. */
+  val absentPrism: Optic[Array[Byte], Array[Byte], Long, Long, Affine] =
+    JsoniterPrism[Long]("$.customer.absent")
+
+  /** array fold `$.lines[*].price` (`Double`). */
+  val pricesTraversal: Optic[Array[Byte], Array[Byte], Double, Double, MultiFocus[PSVec]] =
+    JsoniterTraversal[Double]("$.lines[*].price")
+
+  // ---- hand-rolled partial-scan codecs ------------------------------
+
+  /** Read the value of `target` inside the current JSON object, skipping every other field, then
+    * return `inner` applied to the reader positioned at that value. Returns `default` if the object
+    * / field is absent.
+    */
+  private def field[A](in: JsonReader, target: String, default: A)(inner: JsonReader => A): A =
+    if in.isNextToken('{') then
+      var result = default
+      if !in.isNextToken('}') then
+        in.rollbackToken()
+        while
+          if in.readKeyAsString() == target then result = inner(in)
+          else in.skip()
+          in.isNextToken(',')
+        do ()
+      result
+    else
+      in.rollbackToken()
+      in.skip()
+      default
+
+  /** Hand-rolled scanner for `$.customer.address.street` — walks only the path and `skip()`s
+    * siblings, so the full `Order` is never materialised. A plain `val` (not `given`) so it doesn't
+    * collide with the derived `JsonValueCodec[String]`; passed explicitly to `readFromArray`.
+    */
+  val streetScanCodec: JsonValueCodec[String] = new JsonValueCodec[String]:
+    def nullValue: String = null
+    def encodeValue(x: String, out: JsonWriter): Unit = out.writeVal(x)
+    def decodeValue(in: JsonReader, default: String): String =
+      field(in, "customer", default) { in =>
+        field(in, "address", default) { in =>
+          field(in, "street", default)(_.readString(null))
+        }
+      }
+
+  /** Hand-rolled scanner for `$.lines[*].price` — walks to the `lines` array, sums each element's
+    * `price`, and `skip()`s every sibling at both levels. The line objects are never fully
+    * materialised.
+    */
+  val pricesSumScanCodec: JsonValueCodec[Double] = new JsonValueCodec[Double]:
+    def nullValue: Double = 0.0
+    def encodeValue(x: Double, out: JsonWriter): Unit = out.writeVal(x)
+    def decodeValue(in: JsonReader, default: Double): Double =
+      field(in, "lines", default) { in =>
+        var sum = 0.0
+        if in.isNextToken('[') then
+          if !in.isNextToken(']') then
+            in.rollbackToken()
+            while
+              sum += field(in, "price", 0.0)(_.readDouble())
+              in.isNextToken(',')
+            do ()
+        else in.rollbackToken()
+        sum
+      }

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/DomainOptics.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/DomainOptics.scala
@@ -1,0 +1,64 @@
+package dev.constructive.eo
+package bench
+package fixture
+
+import dev.constructive.eo.data.Affine
+import dev.constructive.eo.optics.{
+  AffineFold,
+  Getter => EoGetter,
+  Optional => EoOptional,
+  Setter => EoSetter,
+}
+
+import monocle.{Getter => MGetter, Optional => MOptional, Setter => MSetter}
+
+/** Canonical in-memory EO + Monocle optics over the decoded [[Order]], for the per-family
+  * micro-benches that don't go through a byte/AST backend (`GetterBench`, `SetterBench`,
+  * `OptionalBench`, `AffineFoldBench`).
+  *
+  * These cover the two canonical foci the integration benches couldn't reach in their own carrier:
+  *   - `order.id: Long` — the advertised Getter / Setter scalar (`$.id`).
+  *   - `customer.loyaltyId: Option[String]` — the advertised Optional / AffineFold focus. Avro
+  *     omits it (kindlings encodes `Option` as a union, not a transparent field — plan 009 caveat),
+  *     but in memory it is exactly an `Optional`/`AffineFold`, so it lives here, not on a synthetic
+  *     record.
+  *
+  * The depth-0/3/6 *composition* sweep stays on `Nested` (see [[NestedOptics]]) — `Order`'s fixed
+  * depth-3 shape can't express it.
+  */
+object DomainOptics:
+
+  /** Populated order (`loyaltyId = Some(...)`) — the Optional / AffineFold Some-branch does work.
+    */
+  val order: Order = Domain.mkOrder(8)
+
+  /** Same order with `loyaltyId = None` — the miss branch. */
+  val orderNoLoyalty: Order =
+    order.copy(customer = order.customer.copy(loyaltyId = None))
+
+  // ---- Getter on order.id -------------------------------------------
+
+  val eoGetId = EoGetter[Order, Long](_.id)
+  val mGetId: MGetter[Order, Long] = MGetter[Order, Long](_.id)
+
+  // ---- Setter on order.id -------------------------------------------
+
+  val eoSetId = EoSetter[Order, Order, Long, Long](f => o => o.copy(id = f(o.id)))
+  val mSetId: MSetter[Order, Long] = MSetter[Order, Long](f => o => o.copy(id = f(o.id)))
+
+  // ---- Optional / AffineFold on customer.loyaltyId ------------------
+
+  val eoLoyalty =
+    EoOptional[Order, Order, String, String, Affine](
+      getOrModify = o => o.customer.loyaltyId.toRight(o),
+      reverseGet = (pair: (Order, String)) =>
+        pair._1.copy(customer = pair._1.customer.copy(loyaltyId = Some(pair._2))),
+    )
+
+  val mLoyalty: MOptional[Order, String] =
+    MOptional[Order, String](_.customer.loyaltyId)(s =>
+      o => o.copy(customer = o.customer.copy(loyaltyId = Some(s)))
+    )
+
+  val eoLoyaltyAF: AffineFold[Order, String] =
+    AffineFold[Order, String](_.customer.loyaltyId)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/TraversalShapes.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/fixture/TraversalShapes.scala
@@ -1,0 +1,30 @@
+package dev.constructive.eo
+package bench
+package fixture
+
+import scala.collection.immutable.ArraySeq
+
+/** Carrier-stress shapes for the PowerSeries / MultiFocus traversal benches.
+  *
+  * These are the shapes the canonical [[Order]] deliberately does **not** have — each isolates a
+  * specific PSVec-carrier cost that `Order.lines` (a single `List` level) can't express, so they
+  * live here as shared, named fixtures rather than as bench-private inner classes:
+  *
+  *   - [[Person]] / [[Phone]] — an `ArraySeq`-backed collection. `PowerSeriesBench` uses `ArraySeq`
+  *     (not `Order`'s `List`) on purpose: `Functor[ArraySeq].map` is a native array walk, so the
+  *     numbers reflect the optic machinery rather than `List`'s pointer-chasing.
+  *   - [[Company]] / [[Department]] / [[Employee]] — a tree-of-trees (a `List` of `ArraySeq`) with
+  *     two separate `Traversal.each` fan-out levels; the canonical schema has only one array level.
+  *   - [[Result]] — a sum type, the vehicle for the Prism-after-Traversal sparse-hit bench. `Order`
+  *     is all products, and plan 009 keeps Prisms on a dedicated ADT.
+  */
+final case class Phone(isMobile: Boolean, number: String)
+final case class Person(name: String, phones: ArraySeq[Phone])
+
+final case class Employee(id: Int, name: String, active: Boolean)
+final case class Department(name: String, employees: ArraySeq[Employee])
+final case class Company(name: String, departments: List[Department])
+
+enum Result:
+  case Ok(value: Int)
+  case Err(msg: String)

--- a/core/src/main/scala/dev/constructive/eo/Composer.scala
+++ b/core/src/main/scala/dev/constructive/eo/Composer.scala
@@ -38,8 +38,8 @@ object Composer extends LowPriorityComposerInstances:
     def to[S, T, A, B](o: Optic[S, T, A, B, Direct]): Optic[S, T, A, B, Tuple2] =
       new Optic[S, T, A, B, Tuple2]:
         type X = Unit
-        val to: S => (X, A) = s => ((), o.to(s))
-        val from: ((X, B)) => T = pair => o.from(pair._2)
+        val to: S => (X, A) = s => ((), o.to(s).value)
+        val from: ((X, B)) => T = pair => o.from(Direct(pair._2))
 
   /** Express an Iso (or Getter) as a Prism — always takes the `Right` branch; `Nothing` in the
     * `Left` slot so the miss branch is uninhabited.
@@ -51,10 +51,10 @@ object Composer extends LowPriorityComposerInstances:
     def to[S, T, A, B](o: Optic[S, T, A, B, Direct]): Optic[S, T, A, B, Either] =
       new Optic[S, T, A, B, Either]:
         type X = Nothing
-        val to: S => Either[X, A] = s => Right(o.to(s))
+        val to: S => Either[X, A] = s => Right(o.to(s).value)
         val from: Either[X, B] => T = e =>
           e match
-            case Right(b) => o.from(b)
+            case Right(b) => o.from(Direct(b))
             case Left(_)  => ???
 
 /** Low-priority `Composer` instances —

--- a/core/src/main/scala/dev/constructive/eo/data/Direct.scala
+++ b/core/src/main/scala/dev/constructive/eo/data/Direct.scala
@@ -5,18 +5,34 @@ import cats.Invariant
 
 import optics.Optic
 
-/** Identity carrier: `Direct[X, A] = A`. `X` is phantom. Used by `Iso` and `Getter` where the focus
-  * is fully determined and no reassembly information is needed — the optic's `to` / `from` are
-  * plain functions, so it is the *forgetful functor* (it forgets the leftover `X` entirely). Its
-  * instances therefore live under the `Forgetful*` typeclasses ([[ForgetfulFunctor]],
-  * [[ForgetfulTraverse]], …). The `F`-shape sibling [[Forget]] lives in its own file.
+/** Identity carrier: `Direct[X, A] = A` (opaque). `X` is phantom. Used by `Iso` and `Getter` where
+  * the focus is fully determined and no reassembly information is needed — the optic's `to` /
+  * `from` are plain functions, so it is the *forgetful functor* (it forgets the leftover `X`
+  * entirely). Its instances therefore live under the `Forgetful*` typeclasses
+  * ([[ForgetfulFunctor]], [[ForgetfulTraverse]], …). The `F`-shape sibling [[Forget]] lives in its
+  * own file.
+  *
+  * `opaque` (not a transparent alias) so it is a *distinct* type for implicit search: `object
+  * Direct` is its companion, so `Accessor[Direct]`, `AssociativeFunctor[Direct, …]`, etc. resolve
+  * via companion scope with no import, and the compiler never dealiases `Direct[X, A]` to `A`
+  * (which would lose those givens). It still erases to `A`, so [[Direct.apply]] (wrap) / [[value]]
+  * (unwrap) are identity at runtime.
   */
-type Direct[X, A] = A
+opaque type Direct[X, A] = A
 
-/** Typeclass instances for [[Direct]]. Every operation collapses to plain function application at
-  * runtime — zero per-call overhead beyond the user's function.
+/** Typeclass instances for [[Direct]], plus the `wrap` / `unwrap` boundary. Every operation
+  * collapses to plain function application at runtime — zero per-call overhead beyond the user's
+  * function.
   */
 object Direct:
+
+  /** Wrap a plain `A` into the `Direct` carrier. Identity at runtime (the opaque type erases to
+    * `A`); needed only so construction sites outside this object satisfy the `Direct[X, A]` type.
+    */
+  transparent inline def apply[X, A](a: A): Direct[X, A] = a
+
+  /** Unwrap the carried `A`. Identity at runtime. */
+  extension [X, A](d: Direct[X, A]) transparent inline def value: A = d
 
   /** Identity read; unlocks `.get` on Iso / Getter. @group Instances */
   given accessor: Accessor[Direct] with

--- a/core/src/main/scala/dev/constructive/eo/data/Forget.scala
+++ b/core/src/main/scala/dev/constructive/eo/data/Forget.scala
@@ -16,7 +16,10 @@ import optics.Optic
   * ([[dev.constructive.eo.data.MultiFocus]]) as a uniform "F-shape carrier" whose optic-level
   * capabilities scale with the typeclasses `F` itself admits.
   */
-type Forget[F[_]] = [X, A] =>> Direct[X, F[A]]
+// `[X, A] =>> F[A]` — the `X` is phantom, so `Forget` is its own transparent carrier (it does *not*
+// route through the now-opaque `Direct`; all the Fold / Forget machinery treats `Forget[F][X, A]`
+// as a plain `F[A]` and relies on that transparency).
+type Forget[F[_]] = [X, A] =>> F[A]
 
 /** Capability ladder for [[Forget]]. Each typeclass on `F` unlocks a matching optic operation:
   *

--- a/core/src/main/scala/dev/constructive/eo/data/MultiFocus.scala
+++ b/core/src/main/scala/dev/constructive/eo/data/MultiFocus.scala
@@ -525,9 +525,9 @@ object MultiFocus:
     def to[S, T, A, B](o: Optic[S, T, A, B, Direct]): Optic[S, T, A, B, MultiFocus[F]] =
       new Optic[S, T, A, B, MultiFocus[F]]:
         type X = Unit
-        val to: S => (Unit, F[A]) = s => ((), Applicative[F].pure(o.to(s)))
+        val to: S => (Unit, F[A]) = s => ((), Applicative[F].pure(o.to(s).value))
         val from: ((Unit, F[B])) => T = {
-          case (_, fb) => o.from(pickSingletonOrThrow(fb, "Direct"))
+          case (_, fb) => o.from(Direct(pickSingletonOrThrow(fb, "Direct")))
         }
 
   /** Forget[F] ↪ MultiFocus[F]. */
@@ -840,10 +840,10 @@ object MultiFocus:
       new Optic[S, T, A, B, MultiFocus[Function1[X0, *]]]:
         type X = Unit
         val to: S => (Unit, X0 => A) = s =>
-          val a = o.to(s)
+          val a = o.to(s).value
           ((), (_: X0) => a)
         val from: ((Unit, X0 => B)) => T = {
-          case (_, k) => o.from(k(null.asInstanceOf[X0]))
+          case (_, k) => o.from(Direct(k(null.asInstanceOf[X0])))
         }
 
   def fromOptionalF[F[_]: MonoidK, S, T, A, B](

--- a/core/src/main/scala/dev/constructive/eo/optics/Getter.scala
+++ b/core/src/main/scala/dev/constructive/eo/optics/Getter.scala
@@ -34,8 +34,8 @@ object Getter:
   */
 final class DirectGetter[S, A](val get: S => A) extends Optic[S, Unit, A, Unit, Direct]:
   type X = Nothing
-  val to: S => A = get
-  val from: Unit => Unit = identity
+  val to: S => Direct[X, A] = s => Direct(get(s))
+  val from: Direct[X, Unit] => Unit = _ => ()
 
   /** Fused `Getter.andThen(Getter)` — composes the read functions; the vestigial `Unit` write path
     * needs no threading.

--- a/core/src/main/scala/dev/constructive/eo/optics/Getter.scala
+++ b/core/src/main/scala/dev/constructive/eo/optics/Getter.scala
@@ -3,9 +3,14 @@ package optics
 
 import data.Direct
 
-/** Constructor for `Getter` — read-only single-focus optic, backed by `Direct` with `T = Unit`.
-  * `.get(s)` is the only operation; no write path. Doesn't compose with other Getters (the inner
-  * `T = Unit` mismatches the outer `B` slot); use a Lens chain and call `.get` on the result.
+/** Constructor for `Getter` — read-only single-focus optic, backed by `Direct` with `T = B = Unit`.
+  * `.get(s)` is the only meaningful operation; the write path is vestigial.
+  *
+  * Both the leftover `T` *and* the back-focus `B` are `Unit`, which makes the read-only-ness
+  * explicit in the type (there is no `B` to put back). [[Getter.apply]] returns a concrete
+  * [[ReadGetter]], so a Getter composes with another Getter through the ordinary `andThen` (the
+  * fused `ReadGetter.andThen`) — `g1.andThen(g2)` reads `s => g2.get(g1.get(s))` — exactly as `Iso`
+  * / `Lens` compose via their own fused subclasses.
   */
 object Getter:
 
@@ -19,8 +24,21 @@ object Getter:
     * val nameLength = Getter[Person, Int](_.name.length)
     *   }}}
     */
-  def apply[S, A](get: S => A): Optic[S, Unit, A, A, Direct] =
-    new Optic[S, Unit, A, A, Direct]:
-      type X = Nothing
-      val to: S => A = get
-      val from: A => Unit = _ => ()
+  def apply[S, A](get: S => A): ReadGetter[S, A] =
+    new ReadGetter(get)
+
+/** Concrete Optic subclass for a read-only getter. Stores `get` directly (so the hot path skips the
+  * `Accessor[Direct]` dispatch the generic extension would perform) and carries a fused `andThen`
+  * for getter∘getter composition — the same shape as [[BijectionIso]] / [[GetReplaceLens]].
+  * Returned by [[Getter.apply]] so hand-written getters pick up the fused path automatically.
+  */
+final class ReadGetter[S, A](val get: S => A) extends Optic[S, Unit, A, Unit, Direct]:
+  type X = Nothing
+  val to: S => A = get
+  val from: Unit => Unit = identity
+
+  /** Fused `Getter.andThen(Getter)` — composes the read functions; the vestigial `Unit` write path
+    * needs no threading.
+    */
+  def andThen[B](inner: ReadGetter[A, B]): ReadGetter[S, B] =
+    new ReadGetter(s => inner.get(get(s)))

--- a/core/src/main/scala/dev/constructive/eo/optics/Getter.scala
+++ b/core/src/main/scala/dev/constructive/eo/optics/Getter.scala
@@ -8,9 +8,9 @@ import data.Direct
   *
   * Both the leftover `T` *and* the back-focus `B` are `Unit`, which makes the read-only-ness
   * explicit in the type (there is no `B` to put back). [[Getter.apply]] returns a concrete
-  * [[ReadGetter]], so a Getter composes with another Getter through the ordinary `andThen` (the
-  * fused `ReadGetter.andThen`) — `g1.andThen(g2)` reads `s => g2.get(g1.get(s))` — exactly as `Iso`
-  * / `Lens` compose via their own fused subclasses.
+  * [[DirectGetter]], so a Getter composes with another Getter through the ordinary `andThen` (the
+  * fused `DirectGetter.andThen`) — `g1.andThen(g2)` reads `s => g2.get(g1.get(s))` — exactly as
+  * `Iso` / `Lens` compose via their own fused subclasses.
   */
 object Getter:
 
@@ -24,15 +24,15 @@ object Getter:
     * val nameLength = Getter[Person, Int](_.name.length)
     *   }}}
     */
-  def apply[S, A](get: S => A): ReadGetter[S, A] =
-    new ReadGetter(get)
+  def apply[S, A](get: S => A): DirectGetter[S, A] =
+    new DirectGetter(get)
 
 /** Concrete Optic subclass for a read-only getter. Stores `get` directly (so the hot path skips the
   * `Accessor[Direct]` dispatch the generic extension would perform) and carries a fused `andThen`
   * for getter∘getter composition — the same shape as [[BijectionIso]] / [[GetReplaceLens]].
   * Returned by [[Getter.apply]] so hand-written getters pick up the fused path automatically.
   */
-final class ReadGetter[S, A](val get: S => A) extends Optic[S, Unit, A, Unit, Direct]:
+final class DirectGetter[S, A](val get: S => A) extends Optic[S, Unit, A, Unit, Direct]:
   type X = Nothing
   val to: S => A = get
   val from: Unit => Unit = identity
@@ -40,5 +40,5 @@ final class ReadGetter[S, A](val get: S => A) extends Optic[S, Unit, A, Unit, Di
   /** Fused `Getter.andThen(Getter)` — composes the read functions; the vestigial `Unit` write path
     * needs no threading.
     */
-  def andThen[B](inner: ReadGetter[A, B]): ReadGetter[S, B] =
-    new ReadGetter(s => inner.get(get(s)))
+  def andThen[B](inner: DirectGetter[A, B]): DirectGetter[S, B] =
+    new DirectGetter(s => inner.get(get(s)))

--- a/core/src/main/scala/dev/constructive/eo/optics/Iso.scala
+++ b/core/src/main/scala/dev/constructive/eo/optics/Iso.scala
@@ -36,8 +36,8 @@ final class BijectionIso[S, T, A, B](
     val reverseGet: B => T,
 ) extends Optic[S, T, A, B, Direct]:
   type X = Nothing
-  val to: S => A = get
-  val from: B => T = reverseGet
+  val to: S => Direct[X, A] = s => Direct(get(s))
+  val from: Direct[X, B] => T = d => reverseGet(d.value)
 
   inline def modify(f: A => B): S => T =
     s => reverseGet(f(get(s)))

--- a/core/src/main/scala/dev/constructive/eo/optics/Optic.scala
+++ b/core/src/main/scala/dev/constructive/eo/optics/Optic.scala
@@ -117,8 +117,8 @@ object Optic:
   def id[A]: Optic[A, A, A, A, Direct] =
     new Optic[A, A, A, A, Direct]:
       type X = Nothing
-      val to: A => A = identity
-      val from: A => A = identity
+      val to: A => Direct[X, A] = a => Direct(a)
+      val from: Direct[X, A] => A = _.value
 
   /** Cross-carrier `.andThen` — picks the direction via a summoned [[Morph]] when the two optics'
     * carriers differ. With one exception (`forget2multifocus` / `multifocus2forget`), cats-eo ships

--- a/docs/plans/2026-06-06-009-feat-benchmark-suite-unification-plan.md
+++ b/docs/plans/2026-06-06-009-feat-benchmark-suite-unification-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Benchmark-suite unification — one canonical schema, real-world coverage"
 type: feat
-status: active
+status: done
 date: 2026-06-06
 ---
 
@@ -273,7 +273,8 @@ non-degenerate case that bench was built to demonstrate.
     derived `generics.prism` (bare `Optic[…,Either]`) reads via `getOption` like
     any other optic. New extension in `Optic.scala` (`@targetName`-disambiguated),
     behaviour test in `OpticsBehaviorSpec`, CHANGELOG entry. Full `sbt test` green.
-- [ ] Phase 3 remainder: FoldBench real-world (`lines[*].price`) row
+- [x] Phase 3 remainder: FoldBench real-world (`lines[*].price`) row — `eoFoldPrices` /
+      `mFoldPrices` over the canonical `LineItem` list, paired EO vs Monocle.
 - [x] Phase 4: JMH preamble decision — **settled by probe.** A `@BenchDefaults`
       meta-annotation was tested empirically and does not work: JMH's generator
       doesn't resolve an annotation's own annotations through to the bench class,
@@ -283,6 +284,26 @@ non-degenerate case that bench was built to demonstrate.
       structurally required and kept deliberately (documented in `JmhDefaults`).
       The safe DRY — the run invocation — is centralised as the `bench` /
       `benchQuick` sbt aliases.
+- [x] **Fixture sprawl fully retired (problem #1 closed).** Every bench-private record
+      definition is gone; the canonical `Order` now drives every micro-bench whose shape it
+      can honestly express:
+      - The three `Order*` codec sets moved out of the bench companions into shared
+        `fixture/Domain{Circe,Jsoniter,Avro}` objects — one definition reused by
+        `OrderCirceBench`, `OrderJsoniterBench`, `OrderAvroBench`, `OpticBuildBench`, and the
+        eo-circe side of `JsoniterBench`.
+      - `LensBench` now benches `Order.id` (depth-1, closes the previously-unbenched scalar
+        focus) **and** `customer.address.street` (deep); `IsoBench` uses `Address`;
+        `TraversalBench` + `MultiFocusBench` use `Order.lines`; `JsoniterBench` is rebuilt on
+        `Order` (the `Payload/User/Profile` fixture is deleted, and its misleading
+        hit-as-miss circe row is dropped — the miss is now an honest eo-jsoniter-only datapoint).
+      - The carrier-stress shapes the canonical schema deliberately lacks — `ArraySeq` phones,
+        the `Company → Department → Employee` tree-of-trees, and the `Result` sum type — moved
+        from bench-private inner classes into a shared, documented `fixture/TraversalShapes.scala`
+        (each carries a scaladoc note on why it isn't `Order`).
+      - `Nested0..6` (depth sweep to 6, which `Order`'s fixed depth-3 can't express) stays in
+        `fixture/Nested.scala` as before. Whole suite compiles under `benchmarks/Jmh/compile`
+        and the migrated benches smoke-run clean (the `OrderJsoniterBench` scanner `require`
+        guards still pass after relocation).
 
 ### Early signal (size 64, `-i 1 -wi 1 -f 1`, smoke only — not publishable)
 

--- a/laws/src/main/scala/dev/constructive/eo/laws/GetterLaws.scala
+++ b/laws/src/main/scala/dev/constructive/eo/laws/GetterLaws.scala
@@ -7,13 +7,14 @@ import _root_.dev.constructive.eo.data.Direct.given
 import optics.Optic
 import optics.Optic.*
 
-/** Law equations for a `Getter[S, A]` — `Optic[S, Unit, A, A, Direct]`.
+/** Law equations for a `Getter[S, A]` — `Optic[S, Unit, A, Unit, Direct]`.
   *
-  * A `Getter` is a read-only optic: its `from` side is fixed to `Unit` so no write path exists. The
-  * only observable behaviour is `get`, which makes the meaningful law a *constructor-correctness*
-  * check: `getter.get(s)` must equal whatever reference function the caller claims the getter
-  * represents. This rules out plumbing mistakes like swapping `_._1` / `_._2` or accidentally
-  * threading the input through `identity`.
+  * A `Getter` is a read-only optic: both its leftover `T` and its back-focus `B` are `Unit` so no
+  * write path exists (and so Getters compose through the ordinary `andThen`). The only observable
+  * behaviour is `get`, which makes the meaningful law a *constructor-correctness* check:
+  * `getter.get(s)` must equal whatever reference function the caller claims the getter represents.
+  * This rules out plumbing mistakes like swapping `_._1` / `_._2` or accidentally threading the
+  * input through `identity`.
   *
   * Compared to Monocle's `GetterLaws`, we drop the fold-consistency law
   * (`getter.fold.getAll(s).headOption == Some(getter.get(s))`) because the `Composer[Direct,
@@ -21,7 +22,7 @@ import optics.Optic.*
   * at this version. Revisit when a new carrier adds that Composer.
   */
 trait GetterLaws[S, A]:
-  def getter: Optic[S, Unit, A, A, Direct]
+  def getter: Optic[S, Unit, A, Unit, Direct]
 
   /** The function this getter is declared to represent. Concrete subclass supplies this — typically
     * the same `S => A` that was passed to `Getter.apply`.

--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -33,18 +33,20 @@ with Actions access can re-run them.
 `eo` is the cats-eo method, `Monocle` the equivalent; `ratio` is `naive`-free —
 just the two optic libraries head to head.
 
-**Lens** (`Tuple2` carrier) — `Person.age`:
+**Lens** (`Tuple2` carrier) — shallow `order.id` and a depth-3 `customer.address.street`:
 
 | Operation | eo | Monocle | ratio |
 |---|--:|--:|--:|
-| `get`     | 1.03 | 1.21 | 1.17× |
-| `replace` | 2.56 | 2.68 | 1.05× |
-| `modify`  | 2.97 | 2.94 | 0.99× |
+| `get` (`id`)          |  1.04 |  1.19 | 1.14× |
+| `replace` (`id`)      |  3.52 |  3.17 | 0.90× |
+| `modify` (`id`)       |  4.06 |  4.05 | 1.00× |
+| `modify` (deep `street`) | 38.93 | 32.84 | 0.84× |
 
-Effectively parity. `GetReplaceLens` stores `get` / `enplace` as plain fields
-and specialises its fused `modify`, so the hot path is a two-function
-composition — no `(X, A)` tuple allocation — matching Monocle's hand-written
-`case class Lens`.
+Effectively parity on the shallow focus. `GetReplaceLens` stores `get` / `enplace`
+as plain fields and specialises its fused `modify`, so the hot path is a
+two-function composition — no `(X, A)` tuple allocation — matching Monocle's
+hand-written `case class Lens`. The depth-3 `street` modify rebuilds three records
+either way and trails Monocle by ~1.2×.
 
 **Prism** (`Either` carrier) — `Option[Int]` plus an `Either[String, Int]`
 Right-prism:
@@ -58,15 +60,17 @@ Right-prism:
 | Right `getOption` (Left)  | 1.08 | 1.17 |
 | Right `reverseGet`        | 2.34 | 2.41 |
 
-**Iso** (`Direct` carrier) — `(Int, String) ↔ Person`:
+**Iso** (`Direct` carrier) — `Address ↔ (String, String, String, String)`:
 
 | Operation | eo | Monocle |
 |---|--:|--:|
-| `get`        | 3.23 | 3.19 |
-| `reverseGet` | 2.54 | 2.71 |
+| `get`        | 3.78 | 3.99 |
+| `reverseGet` | 3.35 | 3.25 |
 
 `BijectionIso` stores both directions as plain fields — same shape and
-direct-call hot path as Monocle's `case class Iso`.
+direct-call hot path as Monocle's `case class Iso`. (`Direct` is now an `opaque
+type`; the `wrap` / `unwrap` at the carrier boundary are `transparent inline`
+identities, so the hot path is unchanged.)
 
 **Optional** (`Affine` carrier) — leaf `Option[String]`, composed through a
 `Nested0..6` Lens chain via cross-carrier `.andThen` (the `Morph[Tuple2, Affine]`
@@ -74,48 +78,59 @@ auto-lifts each hop):
 
 | Operation | eo | Monocle |
 |---|--:|--:|
-| `modify_0` (Some)  |  26.92 | 23.05 |
+| `modify_0` (Some)  |  26.79 | 23.08 |
 | `modify_0` (None)  |   1.51 |  0.99 |
-| `replace_0`        |   5.25 |  3.72 |
-| `modify_3`         |  55.68 | 66.72 |
-| `modify_6`         | 180.55 | 108.86 |
+| `replace_0`        |   5.19 |  3.67 |
+| `modify_3`         |  56.30 | 66.64 |
+| `modify_6`         | 176.41 | 107.96 |
+| `loyaltyId` (Some) |  31.06 | 20.33 |
+| `loyaltyId` (None) |   1.67 |  1.07 |
 
 Competitive across depths: the cross-carrier Lens→Optional chain actually
 *beats* Monocle's native composition at depth 3 (the `Morph[Tuple2, Affine]`
-lift fuses well), and trails ~1.7× at depth 6 where `Affine`'s per-hop branching
-adds up against Monocle's `Option`-specialised internals.
+lift fuses well), and trails ~1.6× at depth 6 where `Affine`'s per-hop branching
+adds up against Monocle's `Option`-specialised internals. The `loyaltyId` rows
+are the canonical `customer.loyaltyId: Option[String]` focus (in memory — Avro
+omits it as a union), Some and None branches.
 
-**Getter / Setter** (`Direct` / `SetterF`) — depth-0/3/6 over `Nested`.
-Neither family composes through `Optic.andThen` in EO today (see
-[Optics → Getter](optics.md#getter)), so the `_3` / `_6` EO numbers nest `.get`
-/ `.modify` calls by hand; Monocle composes natively.
+**Getter / Setter** (`Direct` / `SetterF`) — depth-0/3/6 over `Nested`. Both
+families now compose through the ordinary `.andThen` (Getter via the fused
+`DirectGetter.andThen`; Setter via `SetterF`'s `AssociativeFunctor`), so every
+row builds a *composed* optic on both sides and dispatches through it once —
+apples-to-apples with Monocle's composed `Getter`/`Setter`.
 
 | Depth | Getter eo | Getter Monocle | Setter eo | Setter Monocle |
 |---|--:|--:|--:|--:|
-| `_0` | 0.95 |  0.54 |  2.96 |  2.38 |
-| `_3` | 2.74 |  8.82 | 51.42 | 26.46 |
-| `_6` | 4.55 | 27.65 | 88.23 | 52.35 |
+| `_0` |  0.95 |  0.53 |   2.93 |  2.33 |
+| `_3` | 15.68 |  8.83 |  73.63 | 26.42 |
+| `_6` | 35.13 | 27.42 | 134.13 | 52.51 |
 
-EO resolves `.get` against each carrier's `Accessor` statically, so its composed
-read inlines to a direct call — hence the widening Getter win at depth (~6× by
-depth 6). On write, the nested-`modify` shape costs EO ~1.7× Monocle's native
-`Setter.andThen`.
+Near-parity at the leaf (`order.id`, the canonical scalar focus, reads at the
+same `_0` cost). At depth EO trails Monocle — ~1.3–1.8× on Getter, ~2.5–2.8× on
+Setter — because EO's composed optic is a chain of `s => g2.get(g1.get(s))`
+closures (Getter) / nested `modify` (Setter), while Monocle's composition flattens
+better. *(Earlier docs showed EO winning ~6× at depth; that compared EO's
+hand-nested, inlined `.get` against Monocle's composed optic — not the same thing.
+Now that both compose, the closure-chain overhead is visible and is a future
+optimization target.)*
 
-**Fold / Traversal** — `foldMap(identity)` and `each.modify(_ + 1)` over
-`List[Int]`, sweeping size:
+**Fold / Traversal** — Fold `foldMap(identity)` over `List[Int]`; Traversal
+`each.modify` over the canonical `Order.lines` (bump each line's `qty`), sweeping
+size:
 
 | Size | Fold eo | Fold Monocle | Traversal eo | Traversal Monocle | Traversal speedup |
 |---|--:|--:|--:|--:|--:|
-| 8   |  109.4 |    21.9 |    87.5 |    216.6 | 2.5× |
-| 64  |  932.4 |   313.5 |   620.7 |  1 528.3 | 2.5× |
-| 512 | 8 007.9 | 4 728.1 | 5 218.6 | 34 875.0 | 6.7× |
+| 8   |  109.4 |    21.9 |   114.8 |    241.4 | 2.1× |
+| 64  |  932.4 |   313.5 | 1 035.5 |  1 778.4 | 1.7× |
+| 512 | 8 007.9 | 4 728.1 | 8 735.5 | 34 868.1 | 4.0× |
 
 Monocle's `Fold` reduces to a direct `Foldable.foldMap`; EO's `Forget[F]` adds a
 per-element dispatch layer, so Monocle wins Fold (~1.7–5×). Traversal flips it:
 EO's `each` (carrier `MultiFocus[PSVec]`) collects element references into a flat
 focus vector and rebuilds via `Functor[PSVec].map`, beating Monocle's
-per-element `Applicative[Id]` wrapping — a gap that widens to ~6.7× by 512
-elements.
+per-element `Applicative[Id]` wrapping — a gap that widens to ~4× by 512 line
+items (narrower than the old `List[Int]` sweep, since each element now pays a
+`LineItem` copy that dwarfs the carrier difference).
 
 ## Integration: edit without decoding
 
@@ -191,22 +206,29 @@ every sibling — the optimum a jsoniter expert writes, which eo automates.
 
 | metric | size | eo | native | naive | monocle | eo vs naive |
 |---|--:|--:|--:|--:|--:|--:|
-| `street` read   |   8 | 172 |    732 |   1 972 |   1 984 |  11.5× |
-| `street` read   |  64 | 172 |  3 662 |  11 959 |  11 758 |    70× |
-| `street` read   | 512 | 173 | 27 714 |  97 917 |  94 772 |   565× |
-| `street` modify | 512 | 5 801 | — | 175 728 | 177 531 | 30× |
-| `lines[*].price` fold | 512 | 79 243 | 62 597 | 101 733 | 410 561 | 1.3× |
+| `street` read   |   8 |   199 |    823 |   1 966 |   1 965 |  9.9× |
+| `street` read   |  64 |   199 |  4 037 |  12 431 |  12 467 |   62× |
+| `street` read   | 512 |   199 | 30 993 | 103 689 | 104 042 |  521× |
+| `street` modify | 512 | 3 098 |     — | 176 935 | 176 918 |   57× |
+| `lines[*].price` fold | 512 | 83 125 | 72 193 | 109 393 | 473 147 | 1.3× |
 
-The byte-walk read is **flat at ~172 ns**; even the hand-rolled `native` scan
-scales (it tokenises everything it passes), so eo beats it ~4×. The `modify`
-splice is O(bytes) so it grows mildly but stays ~30× under a re-encode. The
-**fold** must touch every element, so eo lands near `native` and only ~1.3×
-under `naive`.
+The byte-walk read is **flat at ~199 ns**; even the hand-rolled `native` scan
+scales (it tokenises everything it passes), so eo beats it ~4× at size 8 and
+pulls further ahead with size. The `modify` splice is O(bytes) so it grows mildly
+but stays ~57× under a re-encode. The **fold** must touch every element, so eo
+lands near `native` and only ~1.3× under `naive`.
 
-**eo-jsoniter vs eo-circe** (the `JsoniterBench` cross-EO comparison, ~250-byte
-fixture, CI): on one-shot reads — parse + drill — jsoniter beats circe **~8–16×**
-because circe pays `circeParse` every call; the gap narrows to ~2.4× on array
-folds where per-element work dominates. The
+**eo-jsoniter vs eo-circe** (the `JsoniterBench` cross-EO comparison, on the
+canonical `Order` swept over size 8/64/512, CI): eo-circe parses the whole
+document each call (`circeParse` then drill), so it is O(size); the eo-jsoniter
+byte-walk is flat. One-shot scalar read (`$.id`): jsoniter ~41 ns at *every* size
+vs circe 4 502 → 221 163 ns, a gap that grows from **~110× (size 8) to ~5 300×
+(512)** as the parse cost climbs. `.replace`/`.modify $.id`: jsoniter 97 → 2 778
+ns (O(bytes) splice) vs circe ~9 500 → 432 000 ns, **~95–155×**. The array
+`lines[*].price` fold narrows to **~4.7×** — both must visit every element. (A
+deliberately-absent `$.customer.absent` miss costs eo-jsoniter a flat ~182 ns;
+there is no honest circe peer, since a typed codec can't drill an absent field.)
+The
 [design spike](https://github.com/Constructive-Programming/eo/blob/main/docs/research/2026-04-29-eo-jsoniter-spike.md)
 covers the carrier choice and splice mechanics.
 

--- a/site/docs/cookbook.md
+++ b/site/docs/cookbook.md
@@ -1,64 +1,32 @@
 # Cookbook
 
-Runnable patterns for the questions that come up most often.
-Every fence is compiled by mdoc against the current library
-version, and every recipe cites the source — Penner's *Optics By
-Example*, Monocle docs, Haskell `lens` tutorial, circe-optics, or
-cats-eo itself where the surface is novel.
+Runnable patterns for the questions that come up most often. Each
+recipe opens with the problem it solves, every fence is compiled by
+mdoc against the current library version, and every recipe cites
+the source — Penner's *Optics By Example*, Monocle docs, Haskell
+`lens` tutorial, circe-optics, or cats-eo itself where the surface
+is novel.
 
-Recipes are grouped by theme. The order inside each theme moves
-from the most familiar framing to the most cats-eo-unique
-capability; skim the headings for a jumping-off point.
+These are worked examples, not a tutorial — for the optic families
+themselves see the [Optics reference](optics.md). Recipes are
+grouped by theme, moving from the everyday to the most
+cats-eo-unique capability; skim the headings for a jumping-off
+point.
 
 ```scala mdoc:silent
 import dev.constructive.eo.optics.{Iso, Lens, Optic, Optional, Prism, Traversal}
 import dev.constructive.eo.optics.Optic.*
-import dev.constructive.eo.data.Direct.given    // Accessor[Direct] — powers .get on Iso / Getter
 import dev.constructive.eo.data.MultiFocus.given   // Functor / Foldable / Traverse for MultiFocus[PSVec] (post-fold)
 ```
 
 ## Theme A — Product editing
 
-### Edit a deeply-nested coordinate
-
-The canonical Atom/Molecule walk every Haskell tutorial opens
-with — increment a deeply-buried leaf through four composition
-hops:
-
-```scala mdoc:silent
-case class Point(x: Int, y: Int)
-case class Atom(point: Point, mass: Double)
-case class Molecule(atoms: List[Atom])
-
-val everyX =
-  Lens[Molecule, List[Atom]](_.atoms, (m, as) => m.copy(atoms = as))
-    .andThen(Traversal.each[List, Atom])
-    .andThen(Lens[Atom, Point](_.point, (a, p) => a.copy(point = p)))
-    .andThen(Lens[Point, Int](_.x, (p, x) => p.copy(x = x)))
-```
-
-```scala mdoc
-val water = Molecule(List(
-  Atom(Point(0, 0), 1.0),
-  Atom(Point(1, 0), 16.0),
-  Atom(Point(2, 0), 1.0),
-))
-everyX.modify(_ + 1)(water).atoms.map(_.point.x)
-```
-
-Same-carrier Lens hops fuse through `Tuple2`'s
-`AssociativeFunctor`; the cross-carrier hop into `PowerSeries` at
-`.each` happens without a manual `.morph` call. For macro-derived
-versions of these Lenses see [Generics](generics.md).
-
-**Source:** Gonzalez — *Control.Lens.Tutorial*,
-<https://hackage.haskell.org/package/lens-tutorial-1.0.5/docs/Control-Lens-Tutorial.html>.
-
 ### Virtual-field Iso — Celsius ↔ Fahrenheit facade
 
-Expose a `fahrenheit` handle on a `Temperature` whose underlying
-representation is Celsius. Callers `get` and `reverseGet` without
-knowing which unit the type stores:
+**Why:** your type stores Celsius, but half your callers think in
+Fahrenheit. Expose a `fahrenheit` handle that reads and writes as
+if the field were really there — one representation, no drift, and
+the unit choice stays an implementation detail callers never see.
 
 ```scala mdoc:silent
 import dev.constructive.eo.optics.BijectionIso
@@ -92,79 +60,59 @@ details.
 **Source:** Penner — *Virtual Record Fields Using Lenses*,
 <https://chrispenner.ca/posts/virtual-fields>.
 
-### Multi-field NamedTuple focus (cats-eo-unique)
+### Total inventory value — multi-field focus into a fold (cats-eo-unique)
 
-Focus several case-class fields at once and update them
-atomically. The `lens[S](_.a, _.b, ...)` macro returns a Lens
-whose focus is a Scala 3 `NamedTuple` in selector order — no
-Monocle analogue:
+**Why:** you have a basket of line items and want one number —
+total value — without writing a fold by hand or threading two
+fields through a loop. The `lens[S](_.a, _.b)` macro focuses both
+`quantity` and `price` as a single Scala 3 `NamedTuple`, so the
+multiply-and-sum drops straight into `foldMap`. No Monocle
+analogue for the multi-field focus.
 
 ```scala mdoc:silent
+import cats.instances.list.given     // Traverse[List] for .each
+import cats.instances.double.given   // Monoid[Double] for .foldMap
 import dev.constructive.eo.generics.lens
 
 case class OrderItem(sku: String, quantity: Int, price: Double)
 
-val qtyAndPrice = lens[OrderItem](_.quantity, _.price)
+// Focus both pricing fields at once, then walk every item.
+val lineValue =
+  Traversal.each[List, OrderItem]
+    .andThen(lens[OrderItem](_.quantity, _.price))
 ```
 
 ```scala mdoc
-val order = OrderItem("abc-123", 3, 9.99)
+val inventory = List(
+  OrderItem("apple",   3, 9.99),
+  OrderItem("pear",   10, 2.50),
+  OrderItem("lobster", 2, 45.00),
+)
 
-// Atomic multi-field update: see both fields as a NamedTuple,
-// return the NamedTuple with new values.
-qtyAndPrice.modify { nt =>
-  (quantity = nt.quantity * 2, price = nt.price * 0.9)
-}(order)
+// One pass: see each item's (quantity, price) NamedTuple, multiply,
+// and let the Double monoid sum the line values into a grand total.
+lineValue.foldMap(nt => nt.quantity * nt.price)(inventory)
 ```
 
-The selector order determines the NamedTuple shape, so
-`lens[OrderItem](_.price, _.quantity)` would produce a focus
-whose `.price` field comes first. Partial cover → `SimpleLens`;
-full cover flips to a `BijectionIso` (next recipe). See
-[Generics → Multi-field Lens](generics.md)
-for the full treatment.
+The focus arrives in selector order, so `nt.quantity` and
+`nt.price` are named — the lambda reads like the business rule it
+encodes. The same `lineValue` optic also writes (`.modify` to
+re-price every line); the fold is just the read-side escape. See
+[Generics → Multi-field Lens](generics.md) for the full treatment
+of the NamedTuple focus.
 
-**Source:** cats-eo internal.
-
-### Full-cover Iso upgrade (cats-eo-unique)
-
-When the selector set spans *every* case field of `S`, the macro
-silently upgrades from `SimpleLens` to `BijectionIso`. The user
-writes a Lens and the macro delivers a round-trip bijection —
-handy at serialization boundaries:
-
-```scala mdoc:silent
-case class ProductCode(value: String)
-
-// arity-1 wrapper: single-selector full-cover returns BijectionIso,
-// not SimpleLens. The focus type is the Scala 3 NamedTuple
-// NamedTuple[("value",), (String,)] — selector name preserved.
-val codeIso = lens[ProductCode](_.value)
-```
-
-```scala mdoc
-val pc = ProductCode("abc-42")
-val nt = codeIso.get(pc)
-nt.value
-codeIso.reverseGet((value = "zzz-99"))
-codeIso.modify(n => (value = n.value.toUpperCase))(pc)
-```
-
-The return-type switch is deliberate: on full cover there's no
-structural complement left, so the lens degenerates into a
-bijection. Same holds for multi-field full cover — see
-[Generics → Full-cover Iso](generics.md).
-
-**Source:** cats-eo internal.
+**Source:** cats-eo internal; fold framing from Penner — *Optics
+By Example* ch. 7, <https://leanpub.com/optics-by-example/>.
 
 ## Theme B — Sum-branch access
 
 ### Prism + Lens — branch into a case, then edit inside
 
-Branch into a specific enum case and modify a field inside the
-hit branch; the miss branch passes through unchanged. The pattern
-covers both the "update one variant" discriminated-union use case
-and the F#-style expression-tree AST case-dispatch:
+**Why:** you want to rewrite one variant of a sum type — rename
+the bound variable of every `Var` node in an AST, say — and leave
+every other case untouched, without a hand-written `match` that
+re-builds the misses. The Prism selects the branch, the Lens edits
+inside it, and misses pass through for free.
 
 ```scala mdoc:silent
 enum Expr:
@@ -261,25 +209,13 @@ Haskell `lens` `Control.Lens.Plated`,
 
 ## Theme C — Collection walks
 
-### `each` — the composable traversal
+### `each` past the traversal — drill, then keep drilling
 
-cats-eo ships a single Traversal carrier — `Traversal.each`. Map
-over every element of a container, fold via `.foldMap`, and chain
-further optics past the traversal in the same call:
-
-```scala mdoc:silent
-import cats.instances.list.given
-
-val bumpList = Traversal.each[List, Int]
-```
-
-```scala mdoc
-bumpList.modify(_ + 1)(List(1, 2, 3))
-bumpList.foldMap(identity[Int])(List(1, 2, 3))   // sum
-```
-
-`each` shines when the chain continues past the traversal — the
-same map, then drill further into each element:
+**Why:** flip the `isMobile` flag on every phone a subscriber owns.
+The point isn't the map — it's that `each` keeps composing: walk
+into the list, traverse it, *and* drill into a field of each
+element, all in one optic. A plain `.map` would make you re-assemble
+the surrounding `Subscriber` by hand on the way back out.
 
 ```scala mdoc:silent
 case class Dial(isMobile: Boolean, number: String)
@@ -312,11 +248,11 @@ Traversals), <https://leanpub.com/optics-by-example/>; Gonzalez
 
 ### Sparse traversal over a Prism (cats-eo-unique)
 
-For every element of a container, drill through a Prism and
-modify only the hit branch — `Err` elements pass through
-unchanged, `Ok` elements get their `value` bumped. This is the
-"sparse traversal" pattern that's genuinely annoying to
-hand-roll, and the optic spelling is a one-liner:
+**Why:** you have a list of results, some `Ok` and some `Err`, and
+want to bump only the successes — leaving the failures exactly
+where they are. Walking the container *and* matching the branch in
+one pass is the "sparse traversal" that's genuinely annoying to
+hand-roll; here it's a one-liner.
 
 ```scala mdoc:silent
 import scala.collection.immutable.ArraySeq
@@ -359,11 +295,13 @@ Actions) + ch. 10 (Missing Values),
 
 ### The JSON arc — edit leaf, edit array, diagnose
 
-One vignette in three acts: walk a deep JSON path and modify a
-leaf without decoding the siblings; walk every element of a
-nested array; and observe *why* an edit was a silent no-op.
-The [Ior failure-flow diagram](circe.md#failure-flow) covers
-the full decision tree.
+**Why:** you need to change one field deep inside a JSON payload
+and pass the rest through untouched — no full decode into a
+case-class tree, no re-encode, no decoder for the siblings you
+never read. One vignette in three acts: edit a deep leaf, edit
+every element of a nested array, then see *why* an edit was a
+silent no-op. The [Ior failure-flow
+diagram](circe.md#failure-flow) covers the full decision tree.
 
 #### Act 1 — edit one leaf deep in a JSON tree (no decode)
 
@@ -450,7 +388,7 @@ The `Ior.Both(chain, json)` carries both the pre-v0.2 behaviour
 (the unchanged Json) and the diagnostic (the chain). Fold the
 chain into a readable message, route each case to its own log
 stream, or collapse on the `getOrElse` escape hatch — the full
-cascade is Theme I below.
+cascade is Theme H below.
 
 **Source:** cats-eo internal (`JsonPrism`, `JsonTraversal`);
 related to circe-optics' `root.*` idiom
@@ -460,11 +398,12 @@ inspiration from cats' `Ior` typeclass and
 
 ### jq-style path + predicate
 
-"For every `item` whose `price > 100`, uppercase its `name`" —
-expressible in jq as
-`.items[] | select(.price > 100) | .name |= ascii_upcase`. The
-cats-eo rendering reaches through the multi-field focus (Scala 3
-NamedTuple) and branches inside the modify lambda:
+**Why:** the jq one-liner you'd reach for at the shell —
+`.items[] | select(.price > 100) | .name |= ascii_upcase`,
+"uppercase the name of every item over $100" — but in typed Scala,
+over a `Json` you never fully decode. The optic reaches through the
+multi-field focus (a Scala 3 NamedTuple) and branches inside the
+modify lambda:
 
 ```scala mdoc:silent
 type NamePrice = NamedTuple.NamedTuple[("name", "price"), (String, Double)]
@@ -506,10 +445,10 @@ which is honest about the shape of the work.
 
 ### Recursive rename over a user-defined Tree
 
-Walk a user-supplied tree type — the library doesn't need to
-ship a tree carrier when the user's type already has
-`cats.Traverse`. Bring your own `Traverse` and `each` picks it
-up:
+**Why:** rename every leaf of *your own* recursive tree type —
+not a container the library knows about. cats-eo ships no tree
+carrier and doesn't need one: if your type has a `cats.Traverse`,
+`each` picks it up and walks it. Bring your own instance:
 
 ```scala mdoc:silent
 import cats.Traverse
@@ -557,22 +496,25 @@ separately in
 **Source:** Stanislav Glebik — *RefTree talk*,
 <https://stanch.github.io/reftree/docs/talks/Visualize/>.
 
-## Theme E — Algebraic / classifier
+## Theme E — Many focuses at once: rewrite, aggregate, broadcast
 
-`MultiFocus[F]` is the unified successor of five v1 carriers
-(`AlgLens[F]`, `Kaleidoscope`, `Grate`, `PowerSeries`,
-`FixedTraversal[N]`). Every former carrier becomes a sub-shape
-selected by `F`. The three recipes below cover the prototypical
-shapes — see the [MultiFocus reference](multifocus.md) for the full
-unification narrative.
+A `Lens` sees one value; a `Traversal` sees many but only lets you
+map over them. `MultiFocus[F]` is the optic for the jobs in between:
+rewrite *every* slot of a fixed-shape record with one function,
+fold the focused values into a summary and scatter it back across
+them, or walk a nested collection and keep composing past it. The
+three recipes below are the prototypical jobs; the [MultiFocus
+reference](multifocus.md) carries the design story (it unifies five
+separate optics from v1 into this one carrier).
 
-### Recipe A — Prototypical Grate-shape via `MultiFocus.tuple`
+### Recipe A — Adjust every channel of a colour at once
 
-The "broadcast a uniform `A => B` over a homogeneous tuple"
-idiom — the absorbed-Grate sub-shape `MultiFocus[Function1[Int, *]]`.
-Same optic value carries `.modify` (uniform pointwise rewrite)
-and `.modifyA[G]` (effectful pointwise rewrite that short-circuits
-on `G`'s applicative).
+**Why:** you have a fixed-shape record of same-typed fields — the
+R, G, B of a colour, the x/y/z of a vector, the left/right of a
+stereo frame — and you want to hit *all* of them with one function.
+There's no collection to traverse and no reason to write three
+`.copy` calls: focus the whole tuple and rewrite every slot
+uniformly, or fill them all with a constant.
 
 ```scala mdoc:silent
 import cats.instances.function.given  // Functor[Function1[Int, *]] for .modify
@@ -587,39 +529,34 @@ val rgbMF = MultiFocus.tuple[(Double, Double, Double), Double]
 ```scala mdoc
 val violet = (0.5, 0.0, 0.5)
 
-// Brighten all three channels uniformly: the same `A => B` runs at
-// every slot. Same shape as the v1 Grate.modify.
+// Brighten all three channels uniformly: the same function runs at
+// every slot.
 rgbMF.modify(c => (c * 1.4).min(1.0))(violet)
 
 // Replace every slot with the same constant — the broadcast pattern.
 rgbMF.replace(0.0)(violet)
 ```
 
-The carrier is `MultiFocus[Function1[Int, *]]` — `Function1[Int, *]`
-is the Naperian shape over a finite index set. `.modify` runs the
-same closure at every index; `.replace(b)` fills every slot with `b`.
-The absorbed-Grate sub-shape does NOT admit `.modifyA[G]` because
-`Function1[Int, *]` lacks `Traverse` in cats — short-circuiting
-effectful traversal needs a `Foldable + Functor` shape that the
-representable encoding doesn't supply. Reach for
-`MultiFocus.apply[List, Double]` (`F = List`) when the use case
-needs `.modifyA`.
-
-This is the absorbed-Grate sub-shape from the
-[carrier consolidation](multifocus.md#sub-shapes);
-`MultiFocus.representable[F: Representable, A]` covers the same
-shape over arbitrary distributive `F`s (tuple-of-pair `(A, A)`,
-user-defined Naperian containers, etc.).
+`.modify` runs the same function at every slot; `.replace(b)` fills
+every slot with `b`. This is the *Grate* shape of `MultiFocus`
+([details](multifocus.md#sub-shapes)), and it works over any
+fixed-arity homogeneous structure, not just tuples. One caveat: the
+tuple/Grate shape is map-only — when you need an *effectful*
+per-slot rewrite (`.modifyA[G]`), reach for a collection-backed
+`MultiFocus.apply[List, A]` instead.
 
 **Source:** Penner — *Grate: yet another optic*,
 <https://chrispenner.ca/posts/grate>.
 
-### Recipe B — Prototypical Kaleidoscope-shape via `.collectMap` / `.collectList`
+### Recipe B — Summarise a batch, then broadcast or collapse
 
-The "applicative-aware aggregation" idiom — the absorbed-Kaleidoscope
-sub-shape. The same `MultiFocus[F]` optic carries two `.collect*`
-flavours, and the user picks whichever matches the aggregation shape
-they want:
+**Why:** you have a column of numbers from a batch — sensor
+readings, line-item amounts, weights — and you need a summary in a
+particular shape. Sometimes you want it written back into every
+position (so each row carries the batch total as the denominator
+for a "share of total", or the mean as a baseline); sometimes you
+want the batch collapsed to a single value. The same `MultiFocus[F]`
+optic does both — you pick the flavour at the call site:
 
 ```scala mdoc:silent
 import cats.data.ZipList
@@ -629,54 +566,50 @@ val intListMF = MultiFocus.apply[List, Int]
 ```
 
 ```scala mdoc
-// (1) MultiFocus[ZipList] + .collectMap — column-wise mean broadcast
-//     back across positions. The aggregator sees the whole ZipList,
-//     returns one Double, Functor[ZipList].map fills it back at every
-//     index. Length-preserving.
+// (1) .collectMap broadcasts one summary back to every position —
+//     here the batch mean, so every slot ends up holding the average.
+//     (.value just unwraps the ZipList so the result prints legibly.)
 zipMF.collectMap[Double](zl => zl.value.sum / zl.value.size.toDouble)(
   ZipList(List(1.0, 2.0, 3.0, 4.0))
-)
+).value
 
-// (2) MultiFocus[List] + .collectList — cartesian / singleton output:
-//     `List(agg(fa))`, regardless of input length. Reproduces the v1
-//     Reflector[List] semantics at the call site without a typeclass.
+// (2) .collectList collapses the whole batch to a single value —
+//     the total as a one-element result, whatever the input length.
 intListMF.collectList(_.sum)(List(1, 2, 3, 4))
 
-// Same optic, .collectMap flavour: List collapses into the
-// length-preserving (Functor-broadcast) shape — equivalent to the v1
-// Reflector[ZipList] interpretation if it were applied to a List.
+// (3) Same optic, .collectMap flavour: the grand total stamped onto
+//     every position — the denominator for a later "share of total".
 intListMF.collectMap[Int](_.sum)(List(1, 2, 3, 4))
 ```
 
-**When to reach for which `.collect*` flavour.**
+**Which flavour?**
 
-- `.collectMap[B](agg: F[A] => B)` requires `Functor[F]` and is the
-  carrier-wide default. Length-preserving via `Functor[F].map`.
-  Matches v1 `Reflector[ZipList]` and `Reflector[Const]` exactly.
-- `.collectList(agg: List[A] => B)` is `MultiFocus[List]`-specific,
-  produces `List(agg(fa))` — a one-element output regardless of
-  input length. Matches v1 `Reflector[List]`'s cartesian-singleton
-  choice.
+- `.collectMap[B](agg: F[A] => B)` keeps the shape — the summary
+  lands in every position. Reach for it when a downstream step needs
+  the aggregate *alongside* the originals (share-of-total, a
+  normalisation baseline).
+- `.collectList(agg: List[A] => B)` produces a single-element result
+  regardless of input length. Reach for it when you just want the
+  summary.
 
-The post-fold story is the user picks per call site — the
-[carrier-consolidation Q1 finding](multifocus.md#why-two-collect-variants)
-explains why no single derivation from `Apply[F]` covers both
-behaviours uniformly; the v1 `Reflector[F]` typeclass that picked
-one or the other per `F` was deleted.
+Why two flavours, rather than one derived automatically? The
+[MultiFocus reference](multifocus.md#why-two-collect-variants) has
+the answer.
 
 **Sources:** Penner — *Kaleidoscopes: lenses that never die*,
 <https://chrispenner.ca/posts/kaleidoscopes>; Penner —
 *Algebraic lenses*, <https://chrispenner.ca/posts/algebraic>.
 
-### Recipe C — PowerSeries downstream composition (`Lens → each → Lens`)
+### Recipe C — Bulk-edit a nested collection, then read it back
 
-The post-consolidation crown jewel. The absorbed-PowerSeries
-sub-shape `MultiFocus[PSVec]` carries an
-`AssociativeFunctor[MultiFocus[PSVec], _, _]` instance
-(`mfAssocPSVec`), so `.andThen` continues *past* `Traversal.each`
-into a downstream `Lens`. Pre-fold the deleted `Traversal.forEach`
-shape (`Forget[T]`-based) was terminal — a chain ending at
-`.forEach(...)` could not extend further.
+**Why:** the everyday "update all the line items" edit — rename
+every order in a cart, bump every price, flag every overdue
+invoice. The focus lives two hops deep: into the record, then
+across the list it holds. The payoff is that the traversal doesn't
+dead-end — the *same* optic keeps composing past `.each` to reach
+the exact field you want, and folds back out, so one value gives
+you both the write (rename every order) and the read (pull every
+name for a report).
 
 ```scala mdoc:silent
 case class Order(id: Int, name: String, total: Double)
@@ -688,19 +621,12 @@ val cartOrdersL =
 val orderNameL =
   Lens[Order, String](_.name, (o, n) => o.copy(name = n))
 
-// Three hops, two carriers:
-//   Cart →(Tuple2)→ List[Order] →(MultiFocus[PSVec])→ Order →(Tuple2)→ String
-//
-// The cross-carrier hops fire transparently:
-//   - .andThen(Traversal.each[List, Order]) lifts the outer Lens
-//     into MultiFocus[PSVec] via `tuple2multifocusPSVec`.
-//   - .andThen(orderNameL) is the DOWNSTREAM hop — `tuple2multifocusPSVec`
-//     fires again to lift orderNameL into MultiFocus[PSVec], and
-//     mfAssocPSVec composes the two same-carrier optics.
+// Three hops, one .andThen each, no manual .morph:
+//   Cart → its orders (a List) → each order → that order's name
 val everyOrderName =
   cartOrdersL
     .andThen(Traversal.each[List, Order])
-    .andThen(orderNameL)
+    .andThen(orderNameL)   // the downstream hop past .each that pays off
 ```
 
 ```scala mdoc
@@ -718,156 +644,30 @@ everyOrderName.modify(_.toUpperCase)(cart)
 everyOrderName.foldMap((s: String) => List(s))(cart)
 ```
 
-The pre-fold contrast: `Traversal.forEach[F, T](xs)` was a
-`Forget[T]`-carrier optic — the leftover side carried no rebuild
-information, only the read-side aggregation, so chains like
-`.forEach(...).andThen(orderNameL)` were unreachable. The
-post-fold `Traversal.each` is `MultiFocus[PSVec]`-carrier; same
-read-side capability via `.foldMap`, plus the rebuild side that
-makes `.andThen` continue past it.
+The `.andThen(orderNameL)` *after* the traversal is the part that
+earns its keep: because `.each` doesn't dead-end, you compose
+toward the field you actually want instead of stopping at the list
+and re-drilling by hand — and the same value still `.foldMap`s for
+the read side. At scale it stays cheap, within a few percent of a
+hand-tuned traversal up to ~1k elements; the
+[PowerSeries benchmarks](benchmarks.md#powerseries-traversal-with-downstream-composition)
+have the curve.
 
-The `mfAssocPSVec` body is the absorbed `PowerSeries.assoc`
-verbatim — parallel-array `AssocSndZ` leftover, both `MultiFocusSingleton`
-(AlwaysHit, for morphed Lenses) and `MultiFocusPSMaybeHit`
-(MaybeHit, for morphed Prisms / Optionals) fast-paths preserved.
-The benchmark numbers in
-[`docs/research/2026-04-29-powerseries-fold-spike.md` §3.4](https://github.com/Constructive-Programming/eo/blob/main/docs/research/2026-04-29-powerseries-fold-spike.md)
-show the post-fold carrier within ±5% of pre-fold PowerSeries at
-every size up to 1024.
+**Source:** cats-eo internal; performance discussion in
+[Optics → PowerSeries](optics.md#powerseries) and the
+[benchmarks](benchmarks.md#powerseries-traversal-with-downstream-composition).
 
-**Source:** the post-fold composability story; benchmark
-discussion in
-[Optics → PowerSeries](optics.md#powerseries) and
-[benchmarks → PowerSeries with downstream composition](benchmarks.md#powerseries-traversal-with-downstream-composition).
-
-## Theme F — Write-only / read-only escape
-
-### Review — reverse-only build path
-
-Build a `UserId` from a `UUID` through a `Review` so tests and
-prod share one construction path — reverse-only, no observable
-read side:
-
-```scala mdoc:silent
-import java.util.UUID
-import dev.constructive.eo.optics.Review
-
-case class UserId(value: UUID)
-
-val userIdR: Review[UserId, UUID] = Review(UserId(_))
-```
-
-```scala mdoc
-userIdR.reverseGet(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-```
-
-Name the "build-only" intent as first-class and team members
-stop reaching for bare smart constructors. Contrast with
-`Getter` (next recipe) for read-only. `Review` deliberately
-sits *outside* the `Optic` trait — its lack of a read side
-would force an artificial `to` member. See
-[Optics → Review](optics.md#review) for the rationale.
-
-**Source:** Penner — *Optics By Example* ch. 13,
-<https://leanpub.com/optics-by-example/>.
-
-### Getter — derive a read-only view
-
-Expose a derived projection so callers can't try to write
-through it. `Getter[S, A]` wraps a pure `S => A` with
-`T = Unit` on the full optic trait — the mismatch with `B`
-statically rules out `.modify`:
-
-```scala mdoc:silent
-import dev.constructive.eo.optics.Getter
-
-case class Shopper(name: String, age: Int)
-
-val nameInitial = Getter[Shopper, Char](_.name.head)
-```
-
-```scala mdoc
-nameInitial.get(Shopper("Alice", 30))
-```
-
-See the composition note at
-[Optics → Getter](optics.md#getter) — `Getter.andThen(Getter)`
-is handled by composing the underlying `S => A` functions
-directly rather than through `Optic.andThen`, because the
-`T = Unit` slot doesn't align with the outer `B`.
-
-**Source:** Monocle — Focus docs,
-<https://www.optics.dev/Monocle/docs/focus>.
-
-### Setter — opaque bulk write
-
-Encrypt every password in a `UserDb` without exposing the
-plaintext to the call site. `Setter[S, A]` writes but doesn't
-read — the carrier `SetterF` carries no observable read side:
-
-```scala mdoc:silent
-import dev.constructive.eo.optics.Setter
-
-case class Users(credentials: Map[String, String])
-
-val encryptAll = Setter[Users, Users, String, String] { f => users =>
-  users.copy(credentials = users.credentials.view.mapValues(f).toMap)
-}
-```
-
-```scala mdoc
-encryptAll.modify(pw => s"bcrypt($pw)")(
-  Users(Map("alice" -> "s3cret", "bob" -> "hunter2"))
-)
-```
-
-`Setter` is a composition terminal: `lens.andThen(setter)`
-works, `setter.andThen(...)` does not. See the [Setter
-section](optics.md#setter) for the intentional asymmetry.
-
-**Source:** Monocle — Optics docs,
-<https://www.optics.dev/Monocle/docs/optics>.
-
-### AffineFold — predicate-narrowed read
-
-Return `Some(age)` only when the subject is an adult; no
-write-back. `AffineFold` is the 0-or-1 read-only shape with
-`T = Unit`:
-
-```scala mdoc:silent
-import dev.constructive.eo.optics.AffineFold
-
-case class Person(age: Int)
-
-val adultAge: AffineFold[Person, Int] =
-  AffineFold(p => Option.when(p.age >= 18)(p.age))
-```
-
-```scala mdoc
-adultAge.getOption(Person(20))
-adultAge.getOption(Person(15))
-```
-
-Narrow an existing `Optional` or `Prism` to its read-only
-projection via `AffineFold.fromOptional` /
-`AffineFold.fromPrism` — both discard the write / build path
-but keep the matcher. See
-[Optics → AffineFold](optics.md#affinefold) for the
-composition-corner note (direct `.andThen` off a Lens into an
-AffineFold doesn't type-check; narrow after composing).
-
-**Source:** Penner — *Optics By Example* ch. 10 (Missing
-Values), <https://leanpub.com/optics-by-example/>.
-
-## Theme G — Composition
+## Theme F — Composition
 
 ### Three-family ladder: Iso → Lens → Traversal → Prism → Lens
 
-One vignette exercises every `Composer` bridge cats-eo ships,
-with no explicit `.morph` calls anywhere. From a `UserTuple`
-(structurally the same as `UserRecord`), pull out the
-`orders: List[Payment]`, filter to the `Paid` variant, and
-increment their `amount`:
+**Why:** real edits cross optic families — an Iso here, a Lens, a
+Traversal over a list, a Prism into one variant, another Lens
+inside it. In Monocle each adjacent pair needs the right `compose*`
+overload; in cats-eo one `.andThen` bridges every seam with no
+manual `.morph`. Here: from a `UserTuple`, pull out the
+`orders: List[Payment]`, narrow to the `Paid` variant, and bump
+their `amount`:
 
 ```scala mdoc:nest:silent
 final case class UserTuple(name: String, orders: List[Payment])
@@ -928,13 +728,14 @@ concepts page.
 and Borjas' lunar-phase example
 <https://tech.lfborjas.com/optics/>.
 
-## Theme H — Effectful modification
+## Theme G — Effectful modification
 
 ### Validate-in-place with `modifyF`
 
-Bump `age` by 1, but fail with `None` if the input is negative.
-`.modifyF[G]` lifts an `A => G[B]` through any carrier that
-admits `Functor[G]`:
+**Why:** the update can fail. Bump `age` by 1, but reject a
+negative input with `None` — and keep the validation and the write
+as one expression instead of a get / check / set dance. `.modifyF[G]`
+lifts an `A => G[B]` through any carrier that admits `Functor[G]`:
 
 ```scala mdoc:silent
 case class Visitor(name: String, age: Int)
@@ -968,11 +769,12 @@ generalised.
 
 ### Batch-load nested IDs — O(N) → O(1) queries (cats-eo-unique)
 
-Each node in a tree carries an ID that needs to resolve to a
-DB-backed record. Naive `.modifyA` fires one query per node;
-the optic spelling collects all IDs through a `foldMap` pass,
-issues one batched query, then `.modify` again to distribute
-results. 100×–300× without restructuring the domain types:
+**Why:** every node in a structure carries an ID you need to
+resolve against a database, and the naive `.modifyA` fires one
+query per node — the classic N+1. Use the same traversal twice:
+`foldMap` collects every ID in one pass, you issue a single batched
+query, then `.modify` distributes the results back. 100×–300×
+fewer queries with no change to the domain types:
 
 ```scala mdoc:silent
 case class Node(id: Int, label: String)
@@ -1009,11 +811,11 @@ queries*, <https://chrispenner.ca/posts/traversals-for-batching>.
 
 ### Persist-and-stamp — return the stored object with its DB id
 
-A `PUT` (or `POST`) handler receives a draft entity on the wire,
-persists it, and must return the *same* entity enriched with the
-database-assigned id. The id only exists after the effectful store
-runs, so this is the classic "set one field to the result of an
-effect" shape — and a derived id-lens makes the stamp a one-liner.
+**Why:** a `PUT` (or `POST`) handler receives a draft entity on the
+wire, persists it, and must return the *same* entity enriched with
+the database-assigned id. The id only exists after the effectful
+store runs, so this is the classic "set one field to the result of
+an effect" shape — and a derived id-lens makes the stamp a one-liner.
 With circe carrying the value across the wire on both ends, the
 whole handler is a short pipeline: `decode → store → stamp →
 encode`.
@@ -1079,7 +881,7 @@ without the id field; the shape of the pipeline doesn't change.
 <https://gist.github.com/kryptt/af0a626849f0e3f5b16fcd161a5545e4>;
 see also [Generics → Composing into pipelines](generics.md#composing-derived-optics-into-pipelines).
 
-## Theme I — Observable failure (cats-eo-unique)
+## Theme H — Observable failure (cats-eo-unique)
 
 The next three recipes cover the observability story for the
 JSON cursor optics: partial-success walks, parse errors surfaced
@@ -1089,10 +891,11 @@ the full decision tree.
 
 ### Partial-success array walk — `Ior.Both`
 
-Across a mixed-failure array, produce the updated JSON *and*
-the per-element miss list. `Ior.Both(chain, partialJson)` is
-the observable shape — every element that *did* succeed is
-reflected in the payload, every refusal accumulates into the
+**Why:** some elements of the array decode, some don't, and you
+want *both* outcomes — the JSON updated where it could be, and a
+list of which elements were skipped — not a silent drop.
+`Ior.Both(chain, partialJson)` is exactly that shape: every
+success lands in the payload, every refusal accumulates into the
 chain:
 
 ```scala mdoc:silent
@@ -1131,9 +934,11 @@ know you don't want the diagnostic.
 
 ### Parse-error surface — `Json | String` input
 
-When the input is a `String`, unparseable input surfaces as
-`Ior.Left(Chain(JsonFailure.ParseFailed(_)))` through the same
-chain as every other failure mode:
+**Why:** the bytes on the wire might not be JSON at all. Feed the
+optic a raw `String` and a parse failure comes back as
+`Ior.Left(Chain(JsonFailure.ParseFailed(_)))` — through the *same*
+channel as every other failure, so you handle malformed input and
+a missing field with one match:
 
 ```scala mdoc:silent
 val upperName = codecPrism[SimpleBasket].items.each.name.modify(_.toUpperCase)
@@ -1158,10 +963,11 @@ unchanged. Parse cost is zero when the input is already a
 
 ### Classify failures — *why* did the edit no-op?
 
-Pattern-match on each `JsonFailure` case and route to distinct
-log / metric streams. The chain collects one entry per refusal
-point on the walk; the cases cover every way a cursor walk can
-skip:
+**Why:** the edit did nothing and you need to know which step
+refused — a missing path? the wrong shape? a decode failure? — so
+each cause can go to its own log or metric. Pattern-match the
+`JsonFailure` cases; the chain holds one entry per refusal point on
+the walk, covering every way a cursor walk can skip:
 
 ```scala mdoc:silent
 import dev.constructive.eo.circe.JsonFailure
@@ -1192,16 +998,17 @@ service boundaries.
 
 **Source:** cats-eo internal.
 
-## Theme J — Streaming / Kafka
+## Theme I — Streaming / Kafka
 
 ### Kafka payload edit
 
-Most Kafka consumers receive `Array[Byte]` payloads, want to
-modify a single field, and re-emit binary on the producer side.
-The `AvroPrism` triple-input surface accepts `Array[Byte]`
-directly, parses it through apache-avro's `BinaryDecoder` under
-the cached reader schema, and threads the modify back through
-without ever materialising the full case-class tree:
+**Why:** a Kafka consumer gets an `Array[Byte]` payload, needs to
+change one field, and re-emits binary on the producer side — on a
+hot path where decoding the whole record into a case-class tree per
+message is pure overhead. The `AvroPrism` triple-input surface
+takes the `Array[Byte]` directly, parses it through apache-avro's
+`BinaryDecoder` under a cached reader schema, and threads the modify
+back through without ever materialising the full tree:
 
 ```scala mdoc:silent
 import dev.constructive.eo.avro as eoavro

--- a/site/docs/optics.md
+++ b/site/docs/optics.md
@@ -67,8 +67,9 @@ selected by `F`. The full cell-by-cell composition matrix lives in
 ```scala mdoc:silent
 import dev.constructive.eo.optics.{Lens, Optic}
 import dev.constructive.eo.optics.Optic.*
-import dev.constructive.eo.data.Direct.given    // Accessor[Direct] — powers .get on Iso / Getter
 import dev.constructive.eo.data.Forget.given       // ForgetfulFunctor / Fold / Traverse for Forget[F] carriers
+// (Accessor[Direct] etc. now resolve via `object Direct`'s companion scope — `Direct`
+//  is an opaque type, so no `import Direct.given` is needed for `.get` on Iso / Getter.)
 ```
 
 Every page here shows optics constructed by hand. For the
@@ -310,10 +311,14 @@ val nameLen = Getter[Person, Int](_.name.length)
 nameLen.get(Person("Alice", 30))
 ```
 
-Getter → Getter doesn't compose via `Optic.andThen` today
-(Getter's `T = Unit` mismatches the outer `B` slot). For a
-deeper read, compose a Lens chain and call `.get` on the
-composed lens.
+Getter → Getter composes via the ordinary `.andThen` (the fused
+`DirectGetter.andThen`): `g1.andThen(g2).get(s)` reads
+`g2.get(g1.get(s))`.
+
+```scala mdoc
+val initial = Getter[Person, String](_.name).andThen(Getter[String, Char](_.head))
+initial.get(Person("Alice", 30))
+```
 
 ### Setter
 

--- a/tests/src/test/scala/dev/constructive/eo/OpticsBehaviorSpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/OpticsBehaviorSpec.scala
@@ -87,6 +87,13 @@ class OpticsBehaviorSpec extends Specification with ScalaCheck:
     val getter = Getter[(Int, String), Int](_._1)
     val getterOk = forAll((s: (Int, String)) => getter.get(s) == s._1)
 
+    // Getter ∘ Getter composes through the ordinary `andThen` (B = T = Unit, so
+    // the inner T lines up with the outer B and Direct's composeFrom is Unit=>Unit).
+    val composedGetter =
+      Getter[((Int, String), Boolean), (Int, String)](_._1)
+        .andThen(Getter[(Int, String), Int](_._1))
+    val composeOk = forAll((s: ((Int, String), Boolean)) => composedGetter.get(s) == s._1._1)
+
     val l1 = Lens.first[Int, String]
     val l2 = Lens.second[Int, String]
     val curried = Lens.curried[(Int, Int), Int](_._1, a => s => (a, s._2))
@@ -120,7 +127,7 @@ class OpticsBehaviorSpec extends Specification with ScalaCheck:
       .and(posIntPrism.to(-1) === Left(-1))
       .and(posIntPrism.reverseGet(7) === 7)
 
-    getterOk && l1Ok.and(l2Ok) && curriedOk && nestedOk && isoRevOk && prismOk
+    getterOk && composeOk && l1Ok.and(l2Ok) && curriedOk && nestedOk && isoRevOk && prismOk
   }
 
   // ----- Traversal/foldMap/modifyA shorthand --------------------------

--- a/tests/src/test/scala/dev/constructive/eo/OpticsLawsSpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/OpticsLawsSpec.scala
@@ -153,7 +153,7 @@ class OpticsLawsSpec extends Specification with CheckAllHelpers:
 
   // ----- Getter: first projection and a synthetic one ------------
 
-  val firstGetter: Optic[(Int, String), Unit, Int, Int, Direct] =
+  val firstGetter: Optic[(Int, String), Unit, Int, Unit, Direct] =
     Getter[(Int, String), Int](_._1)
 
   checkAll(
@@ -165,7 +165,7 @@ class OpticsLawsSpec extends Specification with CheckAllHelpers:
     .getter,
   )
 
-  val lengthGetter: Optic[String, Unit, Int, Int, Direct] =
+  val lengthGetter: Optic[String, Unit, Int, Unit, Direct] =
     Getter[String, Int](_.length)
 
   checkAll(


### PR DESCRIPTION
Reworks `site/docs/cookbook.md` so every recipe is a motivated, problem-first example instead of a restatement of optics basics. (The rest of the `feat/benchmark-suite-unification` branch already landed on `main` via #17; this PR is just the cookbook delta.)

## What changed

- **Lead with the payoff.** The page now opens on the Celsius↔Fahrenheit virtual-field Iso instead of re-explaining lens composition with the Atom/Molecule walk.
- **Cut the definitions.** Removed the recipes that mostly re-taught optics — the deeply-nested-coordinate walk, the full-cover-Iso mechanics recipe, the basic `each` warm-up, and all of Theme F (Review / Getter / Setter / AffineFold, which live in the optics reference). Remaining themes relabeled contiguously.
- **Stronger multi-field example.** Replaced the atomic multi-field update demo with *total inventory value*: `each → multi-field lens → foldMap(qty * price)` ⇒ `144.97`.
- **Every kept recipe opens with a concrete "why".**
- **Theme E (MultiFocus) reframed around real jobs** — adjust-all-channels, summarise-a-batch (broadcast vs collapse), bulk-edit-then-read — with the carrier-consolidation internals (`mfAssocPSVec`, Naperian/representable, `Reflector` lineage) moved out to the MultiFocus reference. The `ZipList` output is unwrapped with `.value` so the broadcast result is legible.

## Verification

`docs/mdoc` and `docs/laikaSite` both compile clean (0 errors); all fenced examples are evaluated by mdoc against the current library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)