### PR TITLE
perf(core): ForgetFold eager foldMap + reframe & refresh benchmark docs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -198,9 +198,9 @@ All three PowerSeries benches scale **linearly** with traversed-collection size;
 
 Current ratios (see [benchmarks.md](../site/docs/benchmarks.md#powerseries-traversal-with-downstream-composition) for full tables):
 
-- **`PowerSeriesBench` (dense `Lens → Traversal → Lens`):** 5.1× at N=4 → 1.9× at N=1024.
-- **`PowerSeriesNestedBench` (5-hop tree):** 5.4× at N=4 → 2.4× at N=256.
-- **`PowerSeriesPrismBench` (Prism miss-branch):** ~5.5× across sizes — Prism miss plumbing (per-element Either-tag write + miss-branch `ys` slot) is the inherent cost.
+- **`PowerSeriesBench` (dense `Lens → Traversal → Lens`):** 4.7× at N=4 → 2.6× at N=1024.
+- **`PowerSeriesNestedBench` (5-hop tree):** 5.1× at N=4 → 3.2× at N=256.
+- **`PowerSeriesPrismBench` (Prism miss-branch):** ~5.2–5.6× across sizes — Prism miss plumbing (per-element Either-tag write + miss-branch `ys` slot) is the inherent cost.
 
 Under the hood the hot paths use two private fast-path markers on the `MultiFocus[PSVec]` carrier. Prism/Optional morphs mix in `MultiFocusPSMaybeHit` (maybe-hit), whose `collectTo` writes directly into pre-sized flat `Array[Int]` + `Array[AnyRef]` builders (`IntArrBuilder` / `ObjArrBuilder`) without per-element `Either`/`Option` wrappers. Lens morphs mix in the carrier-wide `MultiFocusSingleton` (always-hit), which additionally skips the length-tracking `Array[Int]`. `pEach.to` zero-copies `ArraySeq.ofRef` inputs into a `PSVec.Slice`, and `pEach.from` hands the result `Slice`'s backing array straight to `ArraySeq.unsafeWrapArray` via `unsafeShareableArray` when the Slice densely covers it.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -201,15 +201,13 @@ The remaining Getter/Setter workarounds reflect what a user would actually write
 
 ## Interpreting PowerSeries numbers
 
-All three PowerSeries benches scale **linearly** with traversed-collection size; the eo-to-naive ratios tighten as size grows (fixed per-op setup amortises), while the eo-to-Monocle lead *widens* (Monocle's composed `Traversal` scales worse).
+All three PowerSeries benches scale **linearly** with traversed-collection size; the eo-to-naive ratios tighten as size grows (fixed per-op setup amortises).
 
 Current eo-to-naive ratios (see [benchmarks.md](../site/docs/benchmarks.md#powerseries-traversal-with-downstream-composition) for full tables incl. the Monocle peer):
 
 - **`PowerSeriesBench` (dense `Lens → Traversal → Lens`):** 4.6× at N=4 → 2.7× at N=1024.
 - **`PowerSeriesNestedBench` (5-hop tree):** 5.0× at N=4 → 3.2× at N=256.
 - **`PowerSeriesPrismBench` (Prism miss-branch):** ~5.2–5.6× across sizes — Prism miss plumbing (per-element Either-tag write + miss-branch `ys` slot) is the inherent cost.
-
-Against the Monocle composition EO is faster at every size (`monocle ÷ eo` ~1.4–2× at small N, ~4–6× by the largest) — EO's flat `MultiFocus[PSVec]` rebuilds in one pass where Monocle threads each element through a composed applicative `modifyA`.
 
 Under the hood the hot paths use two private fast-path markers on the `MultiFocus[PSVec]` carrier. Prism/Optional morphs mix in `MultiFocusPSMaybeHit` (maybe-hit), whose `collectTo` writes directly into pre-sized flat `Array[Int]` + `Array[AnyRef]` builders (`IntArrBuilder` / `ObjArrBuilder`) without per-element `Either`/`Option` wrappers. Lens morphs mix in the carrier-wide `MultiFocusSingleton` (always-hit), which additionally skips the length-tracking `Array[Int]`. `pEach.to` zero-copies `ArraySeq.ofRef` inputs into a `PSVec.Slice`, and `pEach.from` hands the result `Slice`'s backing array straight to `ArraySeq.unsafeWrapArray` via `unsafeShareableArray` when the Slice densely covers it.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -142,8 +142,8 @@ The vocabulary is consistent across backends:
   *slower* than a full decode) vs direct `JsonObject` surgery (rebuild only the
   touched parents).
 - `monocle*` — decode to the case class, run a Monocle optic, re-encode. Monocle
-  has no byte/AST carrier, so it must pay the full round-trip — this is where
-  EO's structural-edit advantage shows.
+  has no byte/AST carrier, so it pays the same full round-trip as `naive*` — it's
+  a reference point alongside the hand-written baseline, not a separate story.
 
 | Bench class          | Foci | Baselines | Notes |
 |----------------------|------|-----------|-------|

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -201,13 +201,11 @@ The remaining Getter/Setter workarounds reflect what a user would actually write
 
 ## Interpreting PowerSeries numbers
 
-All three PowerSeries benches scale **linearly** with traversed-collection size; the eo-to-naive ratios tighten as size grows (fixed per-op setup amortises).
+Both `eo` and the hand-written `naive` scale **linearly** in traversed-collection size — verified over the widened sweeps: per-element cost (`ns ÷ element`) flattens once the fixed per-op setup amortises, and a log-log fit gives slopes of **0.9–1.0** for every eo/naive series. The eo-to-naive overhead then settles:
 
-Current eo-to-naive ratios (see [benchmarks.md](../site/docs/benchmarks.md#powerseries-traversal-with-downstream-composition) for full tables incl. the Monocle peer):
-
-- **`PowerSeriesBench` (dense `Lens → Traversal → Lens`):** 4.6× at N=4 → 2.7× at N=1024.
-- **`PowerSeriesNestedBench` (5-hop tree):** 5.0× at N=4 → 3.2× at N=256.
-- **`PowerSeriesPrismBench` (Prism miss-branch):** ~5.2–5.6× across sizes — Prism miss plumbing (per-element Either-tag write + miss-branch `ys` slot) is the inherent cost.
+- **`PowerSeriesBench` (dense `Lens → Traversal → Lens`):** ~2.7× by N=4096 (4.6× at N=4); eo slope 0.91, naive 0.96.
+- **`PowerSeriesNestedBench` (5-hop tree):** ~3.0× by N=1024 (5.0× at N=4); eo slope 0.83, naive 0.91.
+- **`PowerSeriesPrismBench` (Prism miss-branch):** ~5.0–5.6× across sizes — Prism miss plumbing (per-element Either-tag write + miss-branch `ys` slot) is the inherent cost; eo slope 0.98, naive 0.97.
 
 Under the hood the hot paths use two private fast-path markers on the `MultiFocus[PSVec]` carrier. Prism/Optional morphs mix in `MultiFocusPSMaybeHit` (maybe-hit), whose `collectTo` writes directly into pre-sized flat `Array[Int]` + `Array[AnyRef]` builders (`IntArrBuilder` / `ObjArrBuilder`) without per-element `Either`/`Option` wrappers. Lens morphs mix in the carrier-wide `MultiFocusSingleton` (always-hit), which additionally skips the length-tracking `Array[Int]`. `pEach.to` zero-copies `ArraySeq.ofRef` inputs into a `PSVec.Slice`, and `pEach.from` hands the result `Slice`'s backing array straight to `ArraySeq.unsafeWrapArray` via `unsafeShareableArray` when the Slice densely covers it.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -100,13 +100,20 @@ Specifically — the numbers are only meaningful when:
 | `SetterBench`     | `Nested0.value: Int`      | Depths 0 / 3 / 6; see *Composition notes* |
 | `FoldBench`       | `Foldable[List]` + `Monoid[Int]` | `-P size=N` sweep |
 
-### EO-only (no direct Monocle equivalent)
+### Composition + EO-only carrier benches
 
-| Bench class              | Subject | Monocle equivalent |
+The three `PowerSeries*` benches are **Monocle-paired** (`eo` / `naive` / `monocle`):
+they compose Lens/Traversal/Prism, which Monocle does natively, so each ships a
+`monocle_*` peer built from the same chain (with a `@Setup` guard asserting the
+paths agree). The `MultiFocus*` / `JsoniterBench` rows below are genuinely EO-only
+— they probe carrier internals (`MultiFocus[PSVec]` reductions) or compare the two
+EO JSON backends, where there is no Monocle analog.
+
+| Bench class              | Subject | Monocle peer |
 |--------------------------|---------|--------------------|
-| `PowerSeriesBench`       | `Lens → Traversal.each[ArraySeq, Phone] → Lens` over `Person.phones` (sweeps 4/32/256/1024) | None. The `MultiFocus[PSVec]` carrier is the mechanism behind EO's cross-optic composition. |
-| `PowerSeriesNestedBench` | 5-hop `Company → List[Dept] → ArraySeq[Emp] → Boolean` (sweeps 4/32/256 × 4-dept fanout) | None. Stress-tests tree-of-traversals composition. |
-| `PowerSeriesPrismBench`  | `Traversal.each[ArraySeq, Result] → Prism[Result, Int]` on a 50/50 Ok/Err mix (sweeps 8/64/512) | None. Regression oracle for Prism miss-branch plumbing. |
+| `PowerSeriesBench`       | `Lens → Traversal.each[ArraySeq, Phone] → Lens` over `Person.phones` (sweeps 4/32/256/1024) | `MLens.andThen(MTraversal.fromTraverse).andThen(MLens)`. |
+| `PowerSeriesNestedBench` | 5-hop `Company → List[Dept] → ArraySeq[Emp] → Boolean` (sweeps 4/32/256 × 4-dept fanout) | Monocle 5-hop `Lens→Traversal→Lens→Traversal→Lens`. |
+| `PowerSeriesPrismBench`  | `Traversal.each[ArraySeq, Result] → Prism[Result, Int]` on a 50/50 Ok/Err mix (sweeps 8/64/512) | Monocle `Traversal.andThen(Prism)`. |
 | `MultiFocusBench`        | `MultiFocus[List]` (`fromLensF`) vs `MultiFocus[PSVec]` (`Traversal.each`) on the same `Lens → List/each → Lens` chain (sweeps 4/32/256/1024) | None. The unified carrier that absorbed the v1 AlgLens/Kaleidoscope/Grate/PowerSeries families. |
 | `MultiFocusCollectBench` | `collectMap` (ZipList mean / `Const` sum), `collectList` (cartesian-singleton), and `MultiFocus.tuple` 3-/6-slot modifies | None. Carrier-level reduction / broadcast machinery. |
 | `JsoniterBench`         | Cross-EO: `eo-jsoniter` (byte-walk) vs `eo-circe` (AST) read/write at depths 3/4, miss path, `[*]` fold-sum, and `replace`/`modify` writes | None. The two EO JSON backends head-to-head on the same bytes. |
@@ -194,13 +201,15 @@ The remaining Getter/Setter workarounds reflect what a user would actually write
 
 ## Interpreting PowerSeries numbers
 
-All three PowerSeries benches scale **linearly** with traversed-collection size; the eo-to-naive ratios tighten as size grows (fixed per-op setup amortises).
+All three PowerSeries benches scale **linearly** with traversed-collection size; the eo-to-naive ratios tighten as size grows (fixed per-op setup amortises), while the eo-to-Monocle lead *widens* (Monocle's composed `Traversal` scales worse).
 
-Current ratios (see [benchmarks.md](../site/docs/benchmarks.md#powerseries-traversal-with-downstream-composition) for full tables):
+Current eo-to-naive ratios (see [benchmarks.md](../site/docs/benchmarks.md#powerseries-traversal-with-downstream-composition) for full tables incl. the Monocle peer):
 
-- **`PowerSeriesBench` (dense `Lens → Traversal → Lens`):** 4.7× at N=4 → 2.6× at N=1024.
-- **`PowerSeriesNestedBench` (5-hop tree):** 5.1× at N=4 → 3.2× at N=256.
+- **`PowerSeriesBench` (dense `Lens → Traversal → Lens`):** 4.6× at N=4 → 2.7× at N=1024.
+- **`PowerSeriesNestedBench` (5-hop tree):** 5.0× at N=4 → 3.2× at N=256.
 - **`PowerSeriesPrismBench` (Prism miss-branch):** ~5.2–5.6× across sizes — Prism miss plumbing (per-element Either-tag write + miss-branch `ys` slot) is the inherent cost.
+
+Against the Monocle composition EO is faster at every size (`monocle ÷ eo` ~1.4–2× at small N, ~4–6× by the largest) — EO's flat `MultiFocus[PSVec]` rebuilds in one pass where Monocle threads each element through a composed applicative `modifyA`.
 
 Under the hood the hot paths use two private fast-path markers on the `MultiFocus[PSVec]` carrier. Prism/Optional morphs mix in `MultiFocusPSMaybeHit` (maybe-hit), whose `collectTo` writes directly into pre-sized flat `Array[Int]` + `Array[AnyRef]` builders (`IntArrBuilder` / `ObjArrBuilder`) without per-element `Either`/`Option` wrappers. Lens morphs mix in the carrier-wide `MultiFocusSingleton` (always-hit), which additionally skips the length-tracking `Array[Int]`. `pEach.to` zero-copies `ArraySeq.ofRef` inputs into a `PSVec.Slice`, and `pEach.from` hands the result `Slice`'s backing array straight to `ArraySeq.unsafeWrapArray` via `unsafeShareableArray` when the Slice densely covers it.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -111,9 +111,9 @@ EO JSON backends, where there is no Monocle analog.
 
 | Bench class              | Subject | Monocle peer |
 |--------------------------|---------|--------------------|
-| `PowerSeriesBench`       | `Lens → Traversal.each[ArraySeq, Phone] → Lens` over `Person.phones` (sweeps 4/32/256/1024) | `MLens.andThen(MTraversal.fromTraverse).andThen(MLens)`. |
-| `PowerSeriesNestedBench` | 5-hop `Company → List[Dept] → ArraySeq[Emp] → Boolean` (sweeps 4/32/256 × 4-dept fanout) | Monocle 5-hop `Lens→Traversal→Lens→Traversal→Lens`. |
-| `PowerSeriesPrismBench`  | `Traversal.each[ArraySeq, Result] → Prism[Result, Int]` on a 50/50 Ok/Err mix (sweeps 8/64/512) | Monocle `Traversal.andThen(Prism)`. |
+| `PowerSeriesBench`       | `Lens → Traversal.each[ArraySeq, Phone] → Lens` over `Person.phones` (sweeps 4/16/64/256/1024/4096) | `MLens.andThen(MTraversal.fromTraverse).andThen(MLens)`. |
+| `PowerSeriesNestedBench` | 5-hop `Company → List[Dept] → ArraySeq[Emp] → Boolean` (sweeps 4/16/64/256/1024 × 4-dept fanout) | Monocle 5-hop `Lens→Traversal→Lens→Traversal→Lens`. |
+| `PowerSeriesPrismBench`  | `Traversal.each[ArraySeq, Result] → Prism[Result, Int]` on a 50/50 Ok/Err mix (sweeps 8/32/128/512/2048) | Monocle `Traversal.andThen(Prism)`. |
 | `MultiFocusBench`        | `MultiFocus[List]` (`fromLensF`) vs `MultiFocus[PSVec]` (`Traversal.each`) on the same `Lens → List/each → Lens` chain (sweeps 4/32/256/1024) | None. The unified carrier that absorbed the v1 AlgLens/Kaleidoscope/Grate/PowerSeries families. |
 | `MultiFocusCollectBench` | `collectMap` (ZipList mean / `Const` sum), `collectList` (cartesian-singleton), and `MultiFocus.tuple` 3-/6-slot modifies | None. Carrier-level reduction / broadcast machinery. |
 | `JsoniterBench`         | Cross-EO: `eo-jsoniter` (byte-walk) vs `eo-circe` (AST) read/write at depths 3/4, miss path, `[*]` fold-sum, and `replace`/`modify` writes | None. The two EO JSON backends head-to-head on the same bytes. |

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/FoldBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/FoldBench.scala
@@ -7,7 +7,6 @@ import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
 
 import dev.constructive.eo.bench.fixture.{Domain, LineItem}
-import dev.constructive.eo.data.Forget.given
 import dev.constructive.eo.optics.{Fold => EoFold}
 
 import cats.instances.double.given

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/OrderCirceBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/OrderCirceBench.scala
@@ -28,8 +28,8 @@ import io.circe.syntax.*
   *   - `direct*` — direct `JsonObject` surgery (rebuild only the touched parents, no cursor). The
   *     hand-written shape of what `JsonPrism` does, so it lands near `eo*`.
   *   - `monocle*` — decode to the case class, run a Monocle optic, re-encode. A general optics
-  *     library that has *no* AST carrier, so it must pay the full decode/encode round-trip — this
-  *     is where EO's structural-edit advantage shows.
+  *     library that has *no* AST carrier, so it pays the same full decode/encode round-trip as
+  *     `naive*` — a reference point alongside the hand-written baseline, not a separate story.
   *
   * Two foci:
   *   - **depth-3 scalar** `customer.address.street` — touched once. The `@Param size` makes the

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesBench.scala
@@ -12,20 +12,22 @@ import cats.instances.arraySeq.*
 import dev.constructive.eo.bench.fixture.{Person, Phone}
 import dev.constructive.eo.data.MultiFocus.given
 
+import monocle.{Lens => MLens, Traversal => MTraversal}
+
 /** PowerSeries-backed Traversal over a nested focus, paired against a hand-written iterative
-  * baseline.
+  * baseline and the equivalent Monocle composition.
   *
-  * `Traversal.each[ArraySeq, A]` (PowerSeries-backed) is EO-only — Monocle has no direct analog
-  * because the PowerSeries carrier is the mechanism by which EO supports multi-focus traversals
-  * with full `Composer` bridges into `Tuple2` (Lens), `Either` (Prism), and `Affine` (Optional).
-  * This bench documents its runtime cost.
+  * EO's PowerSeries carrier (`MultiFocus[PSVec]`) is an internal mechanism, but the *operation*
+  * this bench measures — a `Lens → Traversal → Lens` chain — is equally expressible in Monocle
+  * (`Lens.andThen(Traversal.fromTraverse).andThen(Lens)`), so the `monocle_*` row is a fair peer
+  * alongside the hand-written `naive_*` baseline.
   *
   * Fixture: `Person(name, phones: ArraySeq[Phone])`. The optic chain drills
   * `Person → phones → each Phone → isMobile` (Boolean). Modify toggles every `isMobile` in-place.
   *
   * The `naive_*` comparator does the same work via `p.copy(phones = p.phones.map(ph =>
-  * ph.copy(isMobile = !ph.isMobile)))` — this is essentially what the PowerSeries chain must
-  * produce, so the gap shows the optic-machinery overhead for multi-focus write.
+  * ph.copy(isMobile = !ph.isMobile)))` — this is essentially what the chain must produce, so the
+  * gap shows each library's optic-machinery overhead for multi-focus write.
   */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -48,11 +50,23 @@ class PowerSeriesBench extends JmhDefaults:
       .andThen(EoTraversal.each[ArraySeq, Phone])
       .andThen(EoLens[Phone, Boolean](_.isMobile, (s, b) => s.copy(isMobile = b)))
 
+  // Same chain in Monocle: Lens → Traversal.fromTraverse → Lens, composing to a Traversal.
+  private val mPersonAllMobiles: MTraversal[Person, Boolean] =
+    MLens[Person, ArraySeq[Phone]](_.phones)(b => s => s.copy(phones = b))
+      .andThen(MTraversal.fromTraverse[ArraySeq, Phone])
+      .andThen(MLens[Phone, Boolean](_.isMobile)(b => s => s.copy(isMobile = b)))
+
   @Setup(Level.Iteration)
   def init(): Unit =
     person = Person(
       "Alice",
       ArraySeq.tabulate(size)(i => Phone(isMobile = i % 2 == 0, s"n-$i")),
+    )
+    // Correctness guard: all three paths produce the same modified record.
+    val eoR = personAllMobiles.modify(!_)(person)
+    require(
+      mPersonAllMobiles.modify(!_)(person) == eoR && naive_powerEach == eoR,
+      "PowerSeriesBench: monocle / naive disagree with eo",
     )
 
   @Benchmark def eoModify_powerEach: Person =
@@ -62,3 +76,6 @@ class PowerSeriesBench extends JmhDefaults:
     person.copy(
       phones = person.phones.map(ph => ph.copy(isMobile = !ph.isMobile))
     )
+
+  @Benchmark def monocle_powerEach: Person =
+    mPersonAllMobiles.modify(!_)(person)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesBench.scala
@@ -37,7 +37,7 @@ import monocle.{Lens => MLens, Traversal => MTraversal}
 @Measurement(iterations = 5, time = 1)
 class PowerSeriesBench extends JmhDefaults:
 
-  @Param(Array("4", "32", "256", "1024"))
+  @Param(Array("4", "16", "64", "256", "1024", "4096"))
   var size: Int = uninitialized
 
   var person: Person = uninitialized

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesNestedBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesNestedBench.scala
@@ -34,7 +34,7 @@ import monocle.{Lens => MLens, Traversal => MTraversal}
   * parallel arrays and re-nest on the way out. A trie keeps the shape explicit and substitutes
   * leaves recursively.
   *
-  * Total elements traversed = `departmentCount × size` (4 × {4, 32, 256}). Inner `size` matches the
+  * Total elements traversed = `departmentCount × size` (4 × {4, 16, 64, 256, 1024}). Inner `size` matches the
   * flat-bench param so comparisons are direct.
   */
 @State(Scope.Benchmark)
@@ -45,7 +45,7 @@ import monocle.{Lens => MLens, Traversal => MTraversal}
 @Measurement(iterations = 5, time = 1)
 class PowerSeriesNestedBench extends JmhDefaults:
 
-  @Param(Array("4", "32", "256"))
+  @Param(Array("4", "16", "64", "256", "1024"))
   var size: Int = uninitialized
 
   private val departmentCount = 4

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesNestedBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesNestedBench.scala
@@ -13,6 +13,8 @@ import cats.instances.list.given
 import dev.constructive.eo.bench.fixture.{Company, Department, Employee}
 import dev.constructive.eo.data.MultiFocus.given
 
+import monocle.{Lens => MLens, Traversal => MTraversal}
+
 /** Nested-traversal PowerSeries bench — tree-of-trees shape.
   *
   * Fixture: `Company(departments: List[Department(employees: ArraySeq[Employee])])`. Every
@@ -62,6 +64,16 @@ class PowerSeriesNestedBench extends JmhDefaults:
       .andThen(EoTraversal.each[ArraySeq, Employee])
       .andThen(EoLens[Employee, Boolean](_.active, (e, b) => e.copy(active = b)))
 
+  // Same 5-hop chain in Monocle: Lens → Traversal → Lens → Traversal → Lens.
+  private val mCompanyAllActive: MTraversal[Company, Boolean] =
+    MLens[Company, List[Department]](_.departments)(ds => c => c.copy(departments = ds))
+      .andThen(MTraversal.fromTraverse[List, Department])
+      .andThen(
+        MLens[Department, ArraySeq[Employee]](_.employees)(es => d => d.copy(employees = es))
+      )
+      .andThen(MTraversal.fromTraverse[ArraySeq, Employee])
+      .andThen(MLens[Employee, Boolean](_.active)(b => e => e.copy(active = b)))
+
   @Setup(Level.Iteration)
   def init(): Unit =
     company = Company(
@@ -73,6 +85,12 @@ class PowerSeriesNestedBench extends JmhDefaults:
         )
       ),
     )
+    // Correctness guard: all three paths produce the same modified tree.
+    val eoR = companyAllActive.modify(!_)(company)
+    require(
+      mCompanyAllActive.modify(!_)(company) == eoR && naive_nested == eoR,
+      "PowerSeriesNestedBench: monocle / naive disagree with eo",
+    )
 
   @Benchmark def eoModify_nested: Company =
     companyAllActive.modify(!_)(company)
@@ -83,3 +101,6 @@ class PowerSeriesNestedBench extends JmhDefaults:
         .departments
         .map(d => d.copy(employees = d.employees.map(e => e.copy(active = !e.active))))
     )
+
+  @Benchmark def monocle_nested: Company =
+    mCompanyAllActive.modify(!_)(company)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesPrismBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesPrismBench.scala
@@ -12,6 +12,8 @@ import cats.instances.arraySeq.given
 import dev.constructive.eo.bench.fixture.Result
 import dev.constructive.eo.data.MultiFocus.given
 
+import monocle.{Prism => MPrism, Traversal => MTraversal}
+
 /** Sparse-Prism PowerSeries bench — half-hit, half-miss per element through a Prism sitting after a
   * Traversal.
   *
@@ -53,10 +55,27 @@ class PowerSeriesPrismBench extends JmhDefaults:
         )
       )
 
+  // Same chain in Monocle: Traversal.fromTraverse → Prism, composing to a Traversal.
+  private val mOkValues: MTraversal[ArraySeq[Result], Int] =
+    MTraversal
+      .fromTraverse[ArraySeq, Result]
+      .andThen(
+        MPrism[Result, Int] {
+          case Result.Ok(v)  => Some(v)
+          case _: Result.Err => None
+        }(Result.Ok(_))
+      )
+
   @Setup(Level.Iteration)
   def init(): Unit =
     results =
       ArraySeq.tabulate(size)(i => if i % 2 == 0 then Result.Ok(i) else Result.Err(s"err-$i"))
+    // Correctness guard: all three paths increment only the Ok cases identically.
+    val eoR = okValues.modify(_ + 1)(results)
+    require(
+      mOkValues.modify(_ + 1)(results) == eoR && naive_sparse == eoR,
+      "PowerSeriesPrismBench: monocle / naive disagree with eo",
+    )
 
   @Benchmark def eoModify_sparse: ArraySeq[Result] =
     okValues.modify(_ + 1)(results)
@@ -66,3 +85,6 @@ class PowerSeriesPrismBench extends JmhDefaults:
       case Result.Ok(v) => Result.Ok(v + 1)
       case other        => other
     }
+
+  @Benchmark def monocle_sparse: ArraySeq[Result] =
+    mOkValues.modify(_ + 1)(results)

--- a/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesPrismBench.scala
+++ b/benchmarks/src/main/scala/dev/constructive/eo/bench/PowerSeriesPrismBench.scala
@@ -37,7 +37,7 @@ import monocle.{Prism => MPrism, Traversal => MTraversal}
 @Measurement(iterations = 5, time = 1)
 class PowerSeriesPrismBench extends JmhDefaults:
 
-  @Param(Array("8", "64", "512"))
+  @Param(Array("8", "32", "128", "512", "2048"))
   var size: Int = uninitialized
 
   var results: ArraySeq[Result] = uninitialized

--- a/core/src/main/scala/dev/constructive/eo/optics/Fold.scala
+++ b/core/src/main/scala/dev/constructive/eo/optics/Fold.scala
@@ -1,12 +1,16 @@
 package dev.constructive.eo
 package optics
 
-import cats.Foldable
+import cats.instances.option.given
+import cats.{Foldable, Monoid}
 import dev.constructive.eo.data.Forget
 
 /** Constructors for `Fold` — read-only multi-focus optic, backed by `Forget[F]` (`Forget[F][X, A] =
   * F[A]`). `T = Unit` rules out the write path; `.foldMap` is the consumption surface.
   * `Fold.select(p)` narrows to a one-element `Option` stream.
+  *
+  * Both constructors return the concrete [[ForgetFold]] subclass so a hand-written Fold picks up
+  * its eager, carrier-free `foldMap` member (see [[ForgetFold.foldMap]]).
   */
 object Fold:
 
@@ -21,18 +25,36 @@ object Fold:
     * listFold.foldMap(identity[Int])(List(1, 2, 3))   // 6
     *   }}}
     */
-  def apply[F[_], A](using
-      @scala.annotation.unused ev: Foldable[F]
-  ): Optic[F[A], Unit, A, A, Forget[F]] =
-    // `Foldable[F]` is documentation; `.foldMap` summons `ForgetfulFold[Forget[F]]` at use site.
-    new Optic[F[A], Unit, A, A, Forget[F]]:
-      type X = Nothing
-      val to: F[A] => F[A] = identity
-      val from: F[A] => Unit = _ => ()
+  def apply[F[_], A](using Foldable[F]): ForgetFold[F[A], F, A] =
+    new ForgetFold[F[A], F, A](identity)
 
   /** Filtering Fold — backed by `Forget[Option]`. @group Constructors */
-  def select[A](p: A => Boolean): Optic[A, Unit, A, A, Forget[Option]] =
-    new Optic[A, Unit, A, A, Forget[Option]]:
-      type X = Nothing
-      val to: A => Option[A] = a => Option(a).filter(p)
-      val from: Option[A] => Unit = _ => ()
+  def select[A](p: A => Boolean): ForgetFold[A, Option, A] =
+    new ForgetFold[A, Option, A](a => Option(a).filter(p))
+
+/** Concrete `Optic` subclass for [[Fold]], storing the source projection `to` and the underlying
+  * `Foldable[F]` directly. This lets the terminal [[foldMap]] fold the focus eagerly through the
+  * captured `Foldable[F]`, skipping both the per-call `ForgetfulFold[Forget[F]]` summon and the
+  * intermediate `S => M` closure the generic `Optic.foldMap` extension builds — the same
+  * specialisation `GetReplaceLens` / `SetterOptic` / `MultiFocusSingleton` apply to their hot
+  * paths.
+  *
+  * Returned by every `Fold.*` constructor so hand-written folds pick up the fast path
+  * automatically. A *composed* Fold (the result of `.andThen`) surfaces as the erased
+  * `Optic[…, Forget[F]]` and keeps the generic extension — the same trade-off [[GetReplaceLens]]
+  * accepts.
+  */
+final class ForgetFold[S, F[_], A](
+    val to: S => F[A]
+)(using FF: Foldable[F])
+    extends Optic[S, Unit, A, A, Forget[F]]:
+  type X = Nothing
+  val from: F[A] => Unit = _ => ()
+
+  /** Eager `foldMap` — folds `s` straight through the captured `Foldable[F]`, returning `M` with no
+    * intermediate `S => M` closure and no `ForgetfulFold` summon. Wins over the [[Optic.foldMap]]
+    * extension by member precedence whenever the receiver is statically a `ForgetFold`; the call
+    * shape (`fold.foldMap(f)(s)`) is identical, so this is a transparent drop-in.
+    */
+  def foldMap[M](f: A => M)(s: S)(using Monoid[M]): M =
+    FF.foldMap(to(s))(f)

--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -306,14 +306,6 @@ settles around 2–3× on the dense Lens and nested chains as element work amort
 the sparse-Prism shape holds ~5× because the miss branch carries inherent
 per-element plumbing.
 
-Against Monocle's equivalent composition EO is **faster at every size**, and the
-lead *widens* as the collection grows (`monocle ÷ eo` rises from ~1.4–2× to
-~4–6×) — opposite to the naive gap, which tightens. Monocle's composed `Traversal`
-scales worse here: the dense Lens chain at 256 is 3 492 ns for EO vs 21 367 for
-Monocle, and the 5-hop tree is 16 655 vs 93 715. EO's flat `MultiFocus[PSVec]`
-focus vector rebuilds in one pass where Monocle threads each element through a
-composed applicative `modifyA`.
-
 Under the hood the carrier pairs an existential leftover with a flat `PSVec`
 focus vector (`Array[AnyRef]` + an `(offset, length)` window), and two internal
 singleton markers (`MultiFocusSingleton` for always-hit Lens morphs,

--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -3,14 +3,16 @@
 JMH numbers from [`benchmarks/`](https://github.com/Constructive-Programming/eo/tree/main/benchmarks),
 in three groups:
 
-1. **[Optic micro-benchmarks](#optic-micro-benchmarks-vs-monocle)** — per-call
-   overhead vs [Monocle](https://www.optics.dev/Monocle/) on the operations both
-   libraries implement.
+1. **[Optic micro-benchmarks](#optic-micro-benchmarks)** — per-call overhead over
+   hand-written field access, with [Monocle](https://www.optics.dev/Monocle/)
+   alongside as the other optics library on the operations both implement.
 2. **[Integration: edit without decoding](#integration-edit-without-decoding)** —
    one realistic `Order` document edited through circe / avro / jsoniter,
-   against decode-modify-encode and other baselines.
+   measured against the decode-modify-encode you'd write by hand (and Monocle,
+   which pays the same round-trip).
 3. **[EO-only: PowerSeries composition](#powerseries-traversal-with-downstream-composition)** —
-   multi-focus traversal chains with no Monocle equivalent.
+   multi-focus traversal chains, measured against the hand-written `copy` + `map`
+   equivalent.
 
 ## How these were measured
 
@@ -32,10 +34,14 @@ table, and for the ratios everywhere, the signal holds.
 > sub-nanosecond truth. See [Reproducing](#reproducing) and
 > [`benchmarks/README.md`](https://github.com/Constructive-Programming/eo/blob/main/benchmarks/README.md).
 
-## Optic micro-benchmarks (vs Monocle)
+## Optic micro-benchmarks
 
-`eo` is the cats-eo method, `Monocle` the equivalent; `ratio` is `naive`-free —
-just the two optic libraries head to head.
+For a single operation the hand-written baseline is direct field access
+(`order.id`) or a `copy` — sub-nanosecond, the floor any optic adds overhead
+over. The honest question these tables answer is *how little* an optic costs over
+that floor. `eo` is the cats-eo method; `Monocle` is the same operation in the
+other optics library, shown alongside as a reference point — the `ratio` column,
+where present, is the two libraries head to head.
 
 **Lens** (`Tuple2` carrier) — shallow `order.id` and a depth-3 `customer.address.street`:
 
@@ -46,11 +52,15 @@ just the two optic libraries head to head.
 | `modify` (`id`)       |  4.06 |  4.05 | 1.00× |
 | `modify` (deep `street`) | 38.93 | 32.84 | 0.84× |
 
-Effectively parity on the shallow focus. `GetReplaceLens` stores `get` / `enplace`
-as plain fields and specialises its fused `modify`, so the hot path is a
-two-function composition — no `(X, A)` tuple allocation — matching Monocle's
-hand-written `case class Lens`. The depth-3 `street` modify rebuilds three records
-either way and trails Monocle by ~1.2×.
+The cost over hand-written field access is essentially nil. `GetReplaceLens`
+stores `get` / `enplace` as plain fields and specialises its fused `modify`, so
+the hot path is a two-function composition — no `(X, A)` tuple allocation — and
+`get` lands within a few tenths of a ns of a bare `order.id`. Monocle sits in the
+same place. **Monocle is faster on the depth-3 `street` modify** (~1.2×): both
+rebuild the same three records, but EO routes that chain through its generic
+existential carrier, which carries a touch more per-hop plumbing than Monocle's
+purpose-built `case class Lens`. We pay that to keep one carrier across every
+optic family; depth-3 is where it first shows.
 
 **Prism** (`Either` carrier) — `Option[Int]` plus an `Either[String, Int]`
 Right-prism:
@@ -90,15 +100,17 @@ auto-lifts each hop):
 | `loyaltyId` (Some) | 27.89 | 20.60 |
 | `loyaltyId` (None) |  1.71 |  1.10 |
 
-EO **beats Monocle at composition depth** — `modify_3` ~1.5× and `modify_6` ~1.26×
-faster — after the fused `andThen` composers became `inline`: each compose site
-splices distinct lambdas, so a deep chain no longer reuses one shared
-`andThen$$anonfun$` bytecode and trips C2's recursive-inline cap (previously
-`modify_6` trailed ~1.6×). Monocle still edges the *single-hit leaf*
-(`modify_0` / `loyaltyId` Some) via its `Option`-specialised internals — EO's
-`Affine` leaf carries a touch more per-hit plumbing. The `loyaltyId` rows are the
-canonical `customer.loyaltyId: Option[String]` focus (in memory — Avro omits it
-as a union), Some and None branches.
+At composition depth the per-hop cost stays low: `modify_3` and `modify_6` track
+the work of a hand-written nested `copy` with an `Option` match at the leaf, since
+the fused `andThen` composers are `inline` — each compose site splices distinct
+lambdas, so a deep chain doesn't reuse one shared `andThen$$anonfun$` bytecode and
+trip C2's recursive-inline cap (before that, `modify_6` was ~1.6× slower). Monocle
+lands a little behind here (`modify_3` ~1.5×, `modify_6` ~1.26×). **Monocle is
+faster at the single-hit leaf** (`modify_0` / `loyaltyId` Some) — its
+`Option`-specialised internals shave the per-hit cost EO's generic `Affine` leaf
+carries to stay uniform across families. The `loyaltyId` rows are the canonical
+`customer.loyaltyId: Option[String]` focus (in memory — Avro omits it as a union),
+Some and None branches.
 
 **Getter / Setter** (`Direct` / `SetterF`) — depth-0/3/6 over `Nested`. Both
 families compose through the fused **`inline` `andThen`** on their concrete
@@ -112,17 +124,20 @@ Monocle's composed `Getter`/`Setter`.
 | `_3` |  5.36 |  8.18 | 11.58 | 26.11 |
 | `_6` | 11.82 | 25.90 | 26.10 | 60.05 |
 
-EO **beats Monocle ~1.5–2.3× at composition depth** for both families. The lever
-is `inline` on the same-carrier `andThen`: each compose site splices a *distinct*
+At composition depth both families stay close to the hand-written baseline — a
+depth-N chain of `.get` calls, or a nested `copy` for the setter. The lever is
+`inline` on the same-carrier `andThen`: each compose site splices a *distinct*
 lambda, so a depth-N chain becomes distinct synthetic methods per level. A plain
 `def` reuses one shared `andThen$$anonfun$` bytecode across the chain, which C2
 reads as recursion and caps (`MaxRecursiveInlineLevel`), leaving the deep tail as
 virtual `Function1.apply`; splicing distinct lambdas sidesteps that cap with no
-JVM flag (the effect Monocle gets from a fresh anonymous class per compose).
-Setter additionally sheds its per-hop `SetterF` allocation (the fused
-`SetterOptic` writes through `modifyFn` directly: depth-6 800→288 B/op). At the
-scalar leaf (`_0`, `order.id`) Monocle edges EO by a few tenths of a ns — the
-sub-nanosecond floor where its specialised case classes shave the last field load.
+JVM flag. Setter additionally sheds its per-hop `SetterF` allocation (the fused
+`SetterOptic` writes through `modifyFn` directly: depth-6 800→288 B/op). Monocle
+gets the same un-capped inlining from a fresh anonymous class per compose, and
+trails here (~1.5–2.3× at `_3`/`_6`). **Monocle is faster at the scalar leaf**
+(`_0`, `order.id`) by a few tenths of a ns — the sub-nanosecond floor where its
+specialised case classes shave the last field load and EO's generic carrier does
+not.
 
 **Fold / Traversal** — Fold `foldMap(identity)` over `List[Int]`; Traversal
 `each.modify` over the canonical `Order.lines` (bump each line's `qty`), sweeping
@@ -130,17 +145,30 @@ size:
 
 | Size | Fold eo | Fold Monocle | Traversal eo | Traversal Monocle | Traversal speedup |
 |---|--:|--:|--:|--:|--:|
-| 8   |  109.4 |    21.9 |   114.8 |    241.4 | 2.1× |
-| 64  |  932.4 |   313.5 | 1 035.5 |  1 778.4 | 1.7× |
-| 512 | 8 007.9 | 4 728.1 | 8 735.5 | 34 868.1 | 4.0× |
+| 8   |    20.1 |    20.4 |   114.8 |    241.4 | 2.1× |
+| 64  |   325.0 |   307.1 | 1 035.5 |  1 778.4 | 1.7× |
+| 512 | 4 535.0 | 4 494.7 | 8 735.5 | 34 868.1 | 4.0× |
 
-Monocle's `Fold` reduces to a direct `Foldable.foldMap`; EO's `Forget[F]` adds a
-per-element dispatch layer, so Monocle wins Fold (~1.7–5×). Traversal flips it:
-EO's `each` (carrier `MultiFocus[PSVec]`) collects element references into a flat
-focus vector and rebuilds via `Functor[PSVec].map`, beating Monocle's
-per-element `Applicative[Id]` wrapping — a gap that widens to ~4× by 512 line
-items (narrower than the old `List[Int]` sweep, since each element now pays a
-`LineItem` copy that dwarfs the carrier difference).
+The hand-written reference is a bare `foldLeft` for the fold and an `xs.map` +
+`copy` for the traversal. **Fold is on par with Monocle** (0.98–1.06× across sizes)
+— both collapse to the *same* `cats.Foldable[List].foldMap`, one `Monoid.combine`
+per element, exactly what a hand-written `foldMap` does. EO's `Fold.apply` returns a
+concrete `ForgetFold` whose eager `foldMap` member folds straight through the
+captured `Foldable[F]` — the same stored-method shape as Monocle's
+`Fold.fromFoldable`. Before that specialisation EO routed every fold through the
+generic `Optic.foldMap` extension, and paid for it: ~5× at size 8 (`109 → 20` ns),
+~2.9× at 64, ~1.8× at 512. That overhead was a per-*call* constant (the
+`ForgetfulFold[Forget[F]]` summon, an intermediate `S => M` closure, and a
+box/unbox), **not** per-element — which is why it dominated small folds and faded
+into the asymptote on large ones. It was also invisible to `-prof gc` (the two were
+always allocation-identical at 14 080 B/op @512; escape analysis elides the
+closure, so the cost was cycles, not bytes — only CI's low-noise timing resolves
+it). The traversal is where the carriers genuinely diverge: EO's `each` (carrier
+`MultiFocus[PSVec]`) collects element references into a flat focus vector and
+rebuilds via `Functor[PSVec].map`, where Monocle wraps each element in
+`Applicative[Id]` — so EO tracks the hand-written `map` more closely and
+Monocle trails, widening to ~4× by 512 line items (each element pays a `LineItem`
+copy that dwarfs the carrier difference).
 
 ## Integration: edit without decoding
 
@@ -211,9 +239,10 @@ record size**, a ~6 800× gap by 512 line items. Array write `lines[*].name`:
 | 64  |  4 758 |  40 987 |  42 613 | 8.6× |
 | 512 | 37 549 | 334 374 | 372 100 | 8.9× |
 
-EO wins ~9× *even on a full-array write* — Avro's per-element decode is costly
-enough that walking to the focused leaf and rebuilding one parent beats decoding
-every line item.
+EO is ~9× faster than the hand-written decode-modify-encode *even on a full-array
+write* — Avro's per-element decode is costly enough that walking to the focused
+leaf and rebuilding one parent beats decoding every line item. (`monocle` here is
+that same round-trip, since Monocle has no `IndexedRecord` carrier.)
 
 ### jsoniter — `JsoniterPrism` / `JsoniterTraversal` over `Array[Byte]`
 
@@ -280,10 +309,11 @@ write directly into pre-sized builders instead of allocating a per-element
 wrapper. The full mechanics and the −59 %…−67 % optimisation history are in the
 [composition notes](https://github.com/Constructive-Programming/eo/blob/main/benchmarks/README.md#composition-notes).
 
-## Plated recursion — read (`universe`) + write (`transform`) vs Monocle vs a hand visitor
+## Plated recursion — read (`universe`) + write (`transform`) vs a hand visitor (and Monocle)
 
-`PlatedBench` pits cats-eo's `Plated` against Monocle's `monocle.function.Plated`
-and the hand-written recursion ("visitor") you'd write without optics, over three
+`PlatedBench` measures cats-eo's `Plated` against the hand-written recursion
+("visitor") you'd write without optics — the baseline that matters — with
+Monocle's `monocle.function.Plated` alongside for reference, over three
 subjects: a normal-depth `Expr` tree, a degenerate deep `Bin` spine, and a
 normal-depth circe `Json` tree (via the universal `Plated[Json]`). The `Plated`
 carrier is PSVec-native, so neither path converts to a `List` and back.
@@ -302,16 +332,17 @@ figures.)
 
 Three results:
 
-- **Monocle's `Plated` is not stack-safe.** On the degenerate spine both
-  `universe` and `transform` `StackOverflowError` at depth ≳2048 (and `universe`,
-  where it survives at 1024, runs ~700× slower than EO — its lazy-`#:::` append
-  going quadratic). EO clears the spine at every size here and at 100k in the
-  stack-safety test, so the deep rows compare EO against the visitor only.
-- **`universe` beats Monocle by ~10–12× and rivals the visitor.** Reading
-  children straight off the PSVec carrier (no `List` round-trip, explicit
-  worklist) puts the JSON subject ~on par with the bare visitor (~1.3×) and
-  `Expr` within ~2×.
-- **`transform` is on par with Monocle and stack-safe.** It went from an
+- **`universe` rivals the hand-written visitor.** Reading children straight off
+  the PSVec carrier (no `List` round-trip, explicit worklist) puts the JSON
+  subject ~on par with the bare visitor (~1.3×) and `Expr` within ~2× — close to
+  the recursion you'd write by hand, while staying composable through `.andThen`.
+  (Monocle is ~10–12× slower here, its lazy-`#:::` append going quadratic, and is
+  *not stack-safe*: both `universe` and `transform` `StackOverflowError` on the
+  degenerate spine at depth ≳2048. EO clears the spine at every size here and at
+  100k in the stack-safety test, so the deep rows compare EO against the visitor
+  only.)
+- **`transform` sits within ~2–3× of the hand-written visitor and is stack-safe.**
+  It went from an
   `Eval` trampoline (was ~10× slower) to a **hybrid**: a direct call-stack
   recursion (≈ a hand-written rebuild — no per-node heap `Frame`) while shallow,
   handing any subtree past a depth bound to the heap-stack machine so a

--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -287,24 +287,43 @@ with Monocle (`Lens.andThen(Traversal.fromTraverse).andThen(Lens)`,
 there too, so it's a fair peer. `Traversal.each` (carrier `MultiFocus[PSVec]`) is
 EO's vehicle for all three; a `@Setup` guard asserts the three paths agree.
 
-| Chain (bench) | Size | eo | naive | monocle | eo ÷ naive |
+| Chain (bench) | N | eo | naive | monocle | eo ÷ naive |
 |---|--:|--:|--:|--:|--:|
-| `Lens → each → Lens` (`PowerSeriesBench`) | 4 | 133 | 29 | 191 | 4.6× |
-| | 32 | 505 | 219 | 1 063 | 2.3× |
-| | 256 | 3 492 | 1 690 | 21 367 | 2.1× |
-| | 1024 | 15 784 | 5 820 | 58 237 | 2.7× |
-| 5-hop tree (`PowerSeriesNestedBench`) | 4 | 724 | 145 | 1 326 | 5.0× |
-| | 32 | 2 365 | 755 | 4 420 | 3.1× |
-| | 256 | 16 655 | 5 244 | 93 715 | 3.2× |
-| `each → Prism`, 50/50 hit (`PowerSeriesPrismBench`) | 8 | 134 | 26 | 279 | 5.2× |
-| | 64 | 748 | 161 | 1 853 | 4.6× |
-| | 512 | 7 179 | 1 292 | 31 386 | 5.6× |
+| `Lens → each → Lens` (`PowerSeriesBench`) | 4 | 133 | 29 | 194 | 4.6× |
+| | 16 | 293 | 111 | 541 | 2.6× |
+| | 64 | 903 | 427 | 2 060 | 2.1× |
+| | 256 | 3 498 | 1 687 | 21 532 | 2.1× |
+| | 1024 | 15 900 | 5 811 | 58 058 | 2.7× |
+| | 4096 | 62 386 | 23 131 | 185 078 | 2.7× |
+| 5-hop tree (`PowerSeriesNestedBench`) | 4 | 728 | 145 | 1 088 | 5.0× |
+| | 16 | 1 425 | 414 | 2 382 | 3.4× |
+| | 64 | 4 437 | 1 479 | 8 889 | 3.0× |
+| | 256 | 16 392 | 5 261 | 92 646 | 3.1× |
+| | 1024 | 68 326 | 22 588 | 254 182 | 3.0× |
+| `each → Prism`, 50/50 hit (`PowerSeriesPrismBench`) | 8 | 135 | 26 | 277 | 5.2× |
+| | 32 | 447 | 84 | 951 | 5.3× |
+| | 128 | 1 613 | 325 | 3 818 | 5.0× |
+| | 512 | 7 254 | 1 294 | 32 455 | 5.6× |
+| | 2048 | 29 246 | 5 590 | 97 415 | 5.2× |
 
-Against the hand-written `naive` baseline all three scale **linearly**: the
-`eo ÷ naive` overhead is largest on tiny inputs (fixed per-op setup dominates) and
-settles around 2–3× on the dense Lens and nested chains as element work amortises;
-the sparse-Prism shape holds ~5× because the miss branch carries inherent
-per-element plumbing.
+Both `eo` and the hand-written `naive` track **O(N)**. The test is per-element
+cost (`ns ÷ element`, traversing `N` leaves — `4N` for the nested tree): once the
+fixed per-op setup amortises past the smallest `N`, it flattens to a constant.
+
+| Chain | eo `ns ÷ element` (N small → large) | naive `ns ÷ element` | log-log slope (eo / naive) |
+|---|---|---|--:|
+| `Lens → each → Lens` | 33 → 18 → 14 → 14 → 16 → 15 | 7.2 → 6.9 → 6.7 → 6.6 → 5.7 → 5.7 | 0.91 / 0.96 |
+| 5-hop tree | 46 → 22 → 17 → 16 → 17 | 9.1 → 6.5 → 5.8 → 5.1 → 5.5 | 0.83 / 0.91 |
+| `each → Prism` | 17 → 14 → 13 → 14 → 14 | 3.2 → 2.6 → 2.5 → 2.5 → 2.7 | 0.98 / 0.97 |
+
+A least-squares fit on `log(time)` vs `log(N)` gives slopes of **0.9–1.0** for
+every eo and naive series (a slope of 1 is exact linearity; the dip below 1 is the
+small-`N` fixed cost, which makes the curve concave — i.e. it rules out
+*super*-linear growth, not linearity). Error bars are ≤3.4% on all eo/naive
+points, so the flattening is signal, not noise. The `eo ÷ naive` overhead settles
+at ~2–3× on the dense Lens and nested chains and ~5× on the sparse Prism (whose
+miss branch carries inherent per-element plumbing). `monocle` is shown for
+reference; its scaling on the shared runner is noisier and not characterised here.
 
 Under the hood the carrier pairs an existential leftover with a flat `PSVec`
 focus vector (`Array[AnyRef]` + an `(offset, length)` window), and two internal

--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -287,18 +287,18 @@ with Monocle (`Lens.andThen(Traversal.fromTraverse).andThen(Lens)`,
 there too, so it's a fair peer. `Traversal.each` (carrier `MultiFocus[PSVec]`) is
 EO's vehicle for all three; a `@Setup` guard asserts the three paths agree.
 
-| Chain (bench) | Size | eo | naive | monocle | eo ÷ naive | monocle ÷ eo |
-|---|--:|--:|--:|--:|--:|--:|
-| `Lens → each → Lens` (`PowerSeriesBench`) | 4 | 133 | 29 | 191 | 4.6× | 1.4× |
-| | 32 | 505 | 219 | 1 063 | 2.3× | 2.1× |
-| | 256 | 3 492 | 1 690 | 21 367 | 2.1× | 6.1× |
-| | 1024 | 15 784 | 5 820 | 58 237 | 2.7× | 3.7× |
-| 5-hop tree (`PowerSeriesNestedBench`) | 4 | 724 | 145 | 1 326 | 5.0× | 1.8× |
-| | 32 | 2 365 | 755 | 4 420 | 3.1× | 1.9× |
-| | 256 | 16 655 | 5 244 | 93 715 | 3.2× | 5.6× |
-| `each → Prism`, 50/50 hit (`PowerSeriesPrismBench`) | 8 | 134 | 26 | 279 | 5.2× | 2.1× |
-| | 64 | 748 | 161 | 1 853 | 4.6× | 2.5× |
-| | 512 | 7 179 | 1 292 | 31 386 | 5.6× | 4.4× |
+| Chain (bench) | Size | eo | naive | monocle | eo ÷ naive |
+|---|--:|--:|--:|--:|--:|
+| `Lens → each → Lens` (`PowerSeriesBench`) | 4 | 133 | 29 | 191 | 4.6× |
+| | 32 | 505 | 219 | 1 063 | 2.3× |
+| | 256 | 3 492 | 1 690 | 21 367 | 2.1× |
+| | 1024 | 15 784 | 5 820 | 58 237 | 2.7× |
+| 5-hop tree (`PowerSeriesNestedBench`) | 4 | 724 | 145 | 1 326 | 5.0× |
+| | 32 | 2 365 | 755 | 4 420 | 3.1× |
+| | 256 | 16 655 | 5 244 | 93 715 | 3.2× |
+| `each → Prism`, 50/50 hit (`PowerSeriesPrismBench`) | 8 | 134 | 26 | 279 | 5.2× |
+| | 64 | 748 | 161 | 1 853 | 4.6× |
+| | 512 | 7 179 | 1 292 | 31 386 | 5.6× |
 
 Against the hand-written `naive` baseline all three scale **linearly**: the
 `eo ÷ naive` overhead is largest on tiny inputs (fixed per-op setup dominates) and

--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -47,39 +47,39 @@ where present, is the two libraries head to head.
 
 | Operation | eo | Monocle | ratio |
 |---|--:|--:|--:|
-| `get` (`id`)          |  1.04 |  1.19 | 1.14× |
-| `replace` (`id`)      |  3.52 |  3.17 | 0.90× |
-| `modify` (`id`)       |  4.06 |  4.05 | 1.00× |
-| `modify` (deep `street`) | 38.93 | 32.84 | 0.84× |
+| `get` (`id`)          |  1.15 |  1.30 | 1.13× |
+| `replace` (`id`)      |  5.16 |  5.13 | 0.99× |
+| `modify` (`id`)       |  5.42 |  5.68 | 1.05× |
+| `modify` (deep `street`) | 36.68 | 31.70 | 0.86× |
 
 The cost over hand-written field access is essentially nil. `GetReplaceLens`
 stores `get` / `enplace` as plain fields and specialises its fused `modify`, so
 the hot path is a two-function composition — no `(X, A)` tuple allocation — and
 `get` lands within a few tenths of a ns of a bare `order.id`. Monocle sits in the
 same place. **Monocle is faster on the depth-3 `street` modify** (~1.2×): both
-rebuild the same three records, but EO routes that chain through its generic
-existential carrier, which carries a touch more per-hop plumbing than Monocle's
-purpose-built `case class Lens`. We pay that to keep one carrier across every
-optic family; depth-3 is where it first shows.
+rebuild the same three records through a fused composed optic (EO's `inline`
+`GetReplaceLens.andThen`, Monocle's composed `Lens`), and EO's per-hop
+`get`/`enplace` closure pair carries a touch more indirection than Monocle's
+purpose-built `case class Lens` — a small constant that first shows at depth 3.
 
 **Prism** (`Either` carrier) — `Option[Int]` plus an `Either[String, Int]`
 Right-prism:
 
 | Operation | eo | Monocle |
 |---|--:|--:|
-| `getOption` Some | 0.93 | 1.06 |
-| `getOption` None | 0.93 | 1.06 |
-| `reverseGet`     | 2.33 | 2.40 |
-| Right `getOption` (Right) | 2.50 | 2.65 |
-| Right `getOption` (Left)  | 1.08 | 1.17 |
-| Right `reverseGet`        | 2.34 | 2.41 |
+| `getOption` Some | 1.01 | 1.15 |
+| `getOption` None | 1.01 | 1.15 |
+| `reverseGet`     | 2.64 | 2.69 |
+| Right `getOption` (Right) | 2.80 | 2.87 |
+| Right `getOption` (Left)  | 1.16 | 1.30 |
+| Right `reverseGet`        | 2.63 | 2.68 |
 
 **Iso** (`Direct` carrier) — `Address ↔ (String, String, String, String)`:
 
 | Operation | eo | Monocle |
 |---|--:|--:|
-| `get`        | 3.78 | 3.99 |
-| `reverseGet` | 3.35 | 3.25 |
+| `get`        | 4.89 | 4.93 |
+| `reverseGet` | 4.29 | 4.40 |
 
 `BijectionIso` stores both directions as plain fields — same shape and
 direct-call hot path as Monocle's `case class Iso`. (`Direct` is now an `opaque
@@ -92,20 +92,20 @@ auto-lifts each hop):
 
 | Operation | eo | Monocle |
 |---|--:|--:|
-| `modify_0` (Some)  | 26.60 | 22.24 |
-| `modify_0` (None)  |  1.58 |  0.95 |
-| `replace_0`        |  4.84 |  3.30 |
-| `modify_3`         | 46.83 | 71.61 |
-| `modify_6`         | 94.18 | 118.86 |
-| `loyaltyId` (Some) | 27.89 | 20.60 |
-| `loyaltyId` (None) |  1.71 |  1.10 |
+| `modify_0` (Some)  | 26.94 | 23.01 |
+| `modify_0` (None)  |  1.51 |  0.98 |
+| `replace_0`        |  5.19 |  3.67 |
+| `modify_3`         | 46.37 | 66.24 |
+| `modify_6`         | 92.10 | 113.55 |
+| `loyaltyId` (Some) | 31.38 | 20.56 |
+| `loyaltyId` (None) |  1.67 |  1.07 |
 
 At composition depth the per-hop cost stays low: `modify_3` and `modify_6` track
 the work of a hand-written nested `copy` with an `Option` match at the leaf, since
 the fused `andThen` composers are `inline` — each compose site splices distinct
 lambdas, so a deep chain doesn't reuse one shared `andThen$$anonfun$` bytecode and
 trip C2's recursive-inline cap (before that, `modify_6` was ~1.6× slower). Monocle
-lands a little behind here (`modify_3` ~1.5×, `modify_6` ~1.26×). **Monocle is
+lands a little behind here (`modify_3` ~1.4×, `modify_6` ~1.2×). **Monocle is
 faster at the single-hit leaf** (`modify_0` / `loyaltyId` Some) — its
 `Option`-specialised internals shave the per-hit cost EO's generic `Affine` leaf
 carries to stay uniform across families. The `loyaltyId` rows are the canonical
@@ -120,9 +120,9 @@ Monocle's composed `Getter`/`Setter`.
 
 | Depth | Getter eo | Getter Monocle | Setter eo | Setter Monocle |
 |---|--:|--:|--:|--:|
-| `_0` |  0.93 |  0.49 |  2.24 |  2.24 |
-| `_3` |  5.36 |  8.18 | 11.58 | 26.11 |
-| `_6` | 11.82 | 25.90 | 26.10 | 60.05 |
+| `_0` |  0.95 |  0.54 |  2.34 |  2.34 |
+| `_3` |  5.12 |  8.81 | 12.21 | 26.30 |
+| `_6` | 11.30 | 27.50 | 26.42 | 52.26 |
 
 At composition depth both families stay close to the hand-written baseline — a
 depth-N chain of `.get` calls, or a nested `copy` for the setter. The lever is
@@ -134,7 +134,7 @@ virtual `Function1.apply`; splicing distinct lambdas sidesteps that cap with no
 JVM flag. Setter additionally sheds its per-hop `SetterF` allocation (the fused
 `SetterOptic` writes through `modifyFn` directly: depth-6 800→288 B/op). Monocle
 gets the same un-capped inlining from a fresh anonymous class per compose, and
-trails here (~1.5–2.3× at `_3`/`_6`). **Monocle is faster at the scalar leaf**
+trails here (~1.7–2.4× at `_3`/`_6`). **Monocle is faster at the scalar leaf**
 (`_0`, `order.id`) by a few tenths of a ns — the sub-nanosecond floor where its
 specialised case classes shave the last field load and EO's generic carrier does
 not.
@@ -145,9 +145,9 @@ size:
 
 | Size | Fold eo | Fold Monocle | Traversal eo | Traversal Monocle | Traversal speedup |
 |---|--:|--:|--:|--:|--:|
-| 8   |    20.1 |    20.4 |   114.8 |    241.4 | 2.1× |
-| 64  |   325.0 |   307.1 | 1 035.5 |  1 778.4 | 1.7× |
-| 512 | 4 535.0 | 4 494.7 | 8 735.5 | 34 868.1 | 4.0× |
+| 8   |    20.1 |    20.4 |   122.4 |    364.0 | 3.0× |
+| 64  |   325.0 |   307.1 |   954.1 |  2 373.4 | 2.5× |
+| 512 | 4 535.0 | 4 494.7 | 8 153.8 | 38 221.2 | 4.7× |
 
 The hand-written reference is a bare `foldLeft` for the fold and an `xs.map` +
 `copy` for the traversal. **Fold is on par with Monocle** (0.98–1.06× across sizes)
@@ -167,7 +167,7 @@ it). The traversal is where the carriers genuinely diverge: EO's `each` (carrier
 `MultiFocus[PSVec]`) collects element references into a flat focus vector and
 rebuilds via `Functor[PSVec].map`, where Monocle wraps each element in
 `Applicative[Id]` — so EO tracks the hand-written `map` more closely and
-Monocle trails, widening to ~4× by 512 line items (each element pays a `LineItem`
+Monocle trails, widening to ~4.7× by 512 line items (each element pays a `LineItem`
 copy that dwarfs the carrier difference).
 
 ## Integration: edit without decoding
@@ -191,22 +191,23 @@ Scalar deep edit, `customer.address.street`:
 
 | size | eo (Unsafe) | eo (Ior) | hcursor | direct | naive | monocle | eo vs naive |
 |--:|--:|--:|--:|--:|--:|--:|--:|
-| 8   | 1 277 | 1 318 | 1 163 | 1 071 |   4 124 |   4 127 |   3.2× |
-| 64  | 1 283 | 1 334 | 1 170 | 1 067 |  25 695 |  24 506 |    20× |
-| 512 | 1 274 | 1 387 | 1 166 | 1 075 | 208 089 | 210 073 |   163× |
+| 8   | 1 050 | 1 059 | 1 080 | 1 013 |   3 748 |   3 769 |   3.6× |
+| 64  | 1 064 | 1 062 | 1 082 | 1 009 |  24 147 |  24 510 |    23× |
+| 512 | 1 058 | 1 059 | 1 068 | 1 015 | 220 535 | 212 179 |   208× |
 
-The edit is **flat** (~1.3 µs at any size); `naive` / `monocle` scale with the
+The edit is **flat** (~1.05 µs at any size); `naive` / `monocle` scale with the
 whole payload. `direct` `JsonObject` surgery is the fastest hand form (what
-`JsonPrism` mirrors); `hcursor` is competitive. The `Ior` surface costs ~40–110 ns
-(one allocation) over `*Unsafe`.
+`JsonPrism` mirrors); `hcursor` is competitive. On this scalar path the `Ior`
+surface is within noise of `*Unsafe` (≤~10 ns); the per-element `Ior` cost shows
+up only on the array traversal below.
 
 Array write-traversal, `lines[*].name`:
 
 | size | eo (Unsafe) | eo (Ior) | hcursor | direct | naive | monocle |
 |--:|--:|--:|--:|--:|--:|--:|
-| 8   |   4 195 |   4 222 |   4 040 |   4 009 |   3 955 |   4 344 |
-| 64  |  30 294 |  33 181 |  30 299 |  29 757 |  26 493 |  27 910 |
-| 512 | 249 409 | 270 847 | 247 216 | 245 600 | 222 527 | 251 872 |
+| 8   |   4 273 |   4 335 |   4 076 |   4 117 |   3 953 |   4 328 |
+| 64  |  30 927 |  32 828 |  29 733 |  29 729 |  26 514 |  26 713 |
+| 512 | 246 620 | 274 840 | 248 995 | 244 976 | 223 026 | 259 373 |
 
 Honest result: a whole-array rewrite is O(elements) for everyone, so the cursor
 walk has no *structural* edge — but EO's `JsonTraversal` now lands right on the
@@ -226,20 +227,20 @@ Scalar `customer.address.street` (`loyaltyId` is omitted — kindlings encodes
 
 | size | eo read | naive read | eo modify | naive modify | read speedup | modify speedup |
 |--:|--:|--:|--:|--:|--:|--:|
-| 8   | 35.5 |   4 995 | 139 |   6 361 |   141× |    46× |
-| 64  | 35.2 |  32 469 | 134 |  39 429 |   922× |   294× |
-| 512 | 36.1 | 244 717 | 137 | 315 918 | 6 780× | 2 310× |
+| 8   | 37.7 |   3 171 | 143 |   4 501 |    84× |    31× |
+| 64  | 37.8 |  18 905 | 145 |  25 774 |   500× |   178× |
+| 512 | 37.7 | 143 746 | 144 | 220 923 | 3 813× | 1 539× |
 
-The flat-vs-linear story at its extreme: a field read is **~35 ns regardless of
-record size**, a ~6 800× gap by 512 line items. Array write `lines[*].name`:
+The flat-vs-linear story at its extreme: a field read is **~38 ns regardless of
+record size**, a ~3 800× gap by 512 line items. Array write `lines[*].name`:
 
 | size | eo | naive | monocle | eo speedup |
 |--:|--:|--:|--:|--:|
-| 8   |    663 |   6 552 |   6 895 | 9.9× |
-| 64  |  4 758 |  40 987 |  42 613 | 8.6× |
-| 512 | 37 549 | 334 374 | 372 100 | 8.9× |
+| 8   |    669 |   4 676 |   5 020 | 7.0× |
+| 64  |  5 149 |  27 417 |  29 271 | 5.3× |
+| 512 | 40 177 | 228 882 | 265 722 | 5.7× |
 
-EO is ~9× faster than the hand-written decode-modify-encode *even on a full-array
+EO is ~5–7× faster than the hand-written decode-modify-encode *even on a full-array
 write* — Avro's per-element decode is costly enough that walking to the focused
 leaf and rebuilding one parent beats decoding every line item. (`monocle` here is
 that same round-trip, since Monocle has no `IndexedRecord` carrier.)
@@ -285,16 +286,16 @@ hand-written `copy` + `map` equivalent.
 
 | Chain (bench) | Size | eo | naive | ratio |
 |---|--:|--:|--:|--:|
-| `Lens → each → Lens` (`PowerSeriesBench`) | 4 | 152 | 26 | 5.8× |
-| | 32 | 504 | 203 | 2.5× |
-| | 256 | 3 409 | 1 616 | 2.1× |
-| | 1024 | 14 364 | 5 530 | 2.6× |
-| 5-hop tree (`PowerSeriesNestedBench`) | 4 | 754 | 130 | 5.8× |
-| | 32 | 2 368 | 698 | 3.4× |
-| | 256 | 15 210 | 4 804 | 3.2× |
-| `each → Prism`, 50/50 hit (`PowerSeriesPrismBench`) | 8 | 146 | 25 | 5.8× |
-| | 64 | 742 | 169 | 4.4× |
-| | 512 | 6 755 | 1 292 | 5.2× |
+| `Lens → each → Lens` (`PowerSeriesBench`) | 4 | 133 | 28 | 4.7× |
+| | 32 | 515 | 216 | 2.4× |
+| | 256 | 3 512 | 1 689 | 2.1× |
+| | 1024 | 15 345 | 5 791 | 2.6× |
+| 5-hop tree (`PowerSeriesNestedBench`) | 4 | 706 | 139 | 5.1× |
+| | 32 | 2 404 | 736 | 3.3× |
+| | 256 | 16 252 | 5 157 | 3.2× |
+| `each → Prism`, 50/50 hit (`PowerSeriesPrismBench`) | 8 | 135 | 26 | 5.2× |
+| | 64 | 750 | 161 | 4.7× |
+| | 512 | 7 174 | 1 282 | 5.6× |
 
 All three scale **linearly**; the ratio to naive is largest on tiny inputs
 (fixed per-op setup dominates) and settles around 2–3× on the dense Lens and
@@ -320,23 +321,23 @@ carrier is PSVec-native, so neither path converts to a `List` and back.
 
 | Op | Subject | eo | monocle | visitor |
 |---|---|--:|--:|--:|
-| `universe` | `Expr` balanced | 15 000 | 172 100 | 6 800 |
-| | `Json` balanced | 20 300 | 207 900 | 16 100 |
-| | `Bin` deep spine | 15 600 | **SO** | 6 900 |
-| `transform` | `Expr` balanced | 18 200 | 14 700 | 8 400 |
-| | `Bin` deep spine | 13 000 | **SO** | 4 100 |
+| `universe` | `Expr` balanced | 113 953 | 1 702 000 | 55 248 |
+| | `Json` balanced | 198 254 | 2 051 033 | 130 461 |
+| | `Bin` deep spine | 121 068 | **SO** | 60 927 |
+| `transform` | `Expr` balanced | 153 129 | 184 118 | 73 443 |
+| | `Bin` deep spine | 132 753 | **SO** | 44 744 |
 
-(ns/op at n=512, 3-fork; **indicative only** — this machine is noisy enough that
-sub-2× differences aren't significant. The CI workflow produces the canonical
-figures.)
+(ns/op at n=512, from the reproducible CI benchmarks workflow — 3-fork on the
+shared runner, so absolute numbers run higher than a quiet desktop; the ratios are
+the signal and sub-~1.5× differences aren't meaningful. **SO** = `StackOverflowError`.)
 
 Three results:
 
 - **`universe` rivals the hand-written visitor.** Reading children straight off
   the PSVec carrier (no `List` round-trip, explicit worklist) puts the JSON
-  subject ~on par with the bare visitor (~1.3×) and `Expr` within ~2× — close to
-  the recursion you'd write by hand, while staying composable through `.andThen`.
-  (Monocle is ~10–12× slower here, its lazy-`#:::` append going quadratic, and is
+  subject ~1.5× the bare visitor and `Expr` within ~2× — close to the recursion
+  you'd write by hand, while staying composable through `.andThen`.
+  (Monocle is ~10–15× slower here, its lazy-`#:::` append going quadratic, and is
   *not stack-safe*: both `universe` and `transform` `StackOverflowError` on the
   degenerate spine at depth ≳2048. EO clears the spine at every size here and at
   100k in the stack-safety test, so the deep rows compare EO against the visitor

--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -10,9 +10,9 @@ in three groups:
    one realistic `Order` document edited through circe / avro / jsoniter,
    measured against the decode-modify-encode you'd write by hand (and Monocle,
    which pays the same round-trip).
-3. **[EO-only: PowerSeries composition](#powerseries-traversal-with-downstream-composition)** —
-   multi-focus traversal chains, measured against the hand-written `copy` + `map`
-   equivalent.
+3. **[PowerSeries composition](#powerseries-traversal-with-downstream-composition)** —
+   composed multi-focus traversal chains, measured against the hand-written
+   `copy` + `map` and the equivalent Monocle composition.
 
 ## How these were measured
 
@@ -280,27 +280,39 @@ covers the carrier choice and splice mechanics.
 
 ## PowerSeries traversal with downstream composition
 
-EO-only — no Monocle equivalent. `Traversal.each` (carrier `MultiFocus[PSVec]`)
-is the composition vehicle for all three chain shapes; `naive` is the
-hand-written `copy` + `map` equivalent.
+Three composed-traversal chains. `naive` is the hand-written `copy` + `map`
+equivalent — the baseline that matters. `monocle` is the *same* composition built
+with Monocle (`Lens.andThen(Traversal.fromTraverse).andThen(Lens)`,
+`Traversal.andThen(Prism)`, nested traversals) — these compositions are first-class
+there too, so it's a fair peer. `Traversal.each` (carrier `MultiFocus[PSVec]`) is
+EO's vehicle for all three; a `@Setup` guard asserts the three paths agree.
 
-| Chain (bench) | Size | eo | naive | ratio |
-|---|--:|--:|--:|--:|
-| `Lens → each → Lens` (`PowerSeriesBench`) | 4 | 133 | 28 | 4.7× |
-| | 32 | 515 | 216 | 2.4× |
-| | 256 | 3 512 | 1 689 | 2.1× |
-| | 1024 | 15 345 | 5 791 | 2.6× |
-| 5-hop tree (`PowerSeriesNestedBench`) | 4 | 706 | 139 | 5.1× |
-| | 32 | 2 404 | 736 | 3.3× |
-| | 256 | 16 252 | 5 157 | 3.2× |
-| `each → Prism`, 50/50 hit (`PowerSeriesPrismBench`) | 8 | 135 | 26 | 5.2× |
-| | 64 | 750 | 161 | 4.7× |
-| | 512 | 7 174 | 1 282 | 5.6× |
+| Chain (bench) | Size | eo | naive | monocle | eo ÷ naive | monocle ÷ eo |
+|---|--:|--:|--:|--:|--:|--:|
+| `Lens → each → Lens` (`PowerSeriesBench`) | 4 | 133 | 29 | 191 | 4.6× | 1.4× |
+| | 32 | 505 | 219 | 1 063 | 2.3× | 2.1× |
+| | 256 | 3 492 | 1 690 | 21 367 | 2.1× | 6.1× |
+| | 1024 | 15 784 | 5 820 | 58 237 | 2.7× | 3.7× |
+| 5-hop tree (`PowerSeriesNestedBench`) | 4 | 724 | 145 | 1 326 | 5.0× | 1.8× |
+| | 32 | 2 365 | 755 | 4 420 | 3.1× | 1.9× |
+| | 256 | 16 655 | 5 244 | 93 715 | 3.2× | 5.6× |
+| `each → Prism`, 50/50 hit (`PowerSeriesPrismBench`) | 8 | 134 | 26 | 279 | 5.2× | 2.1× |
+| | 64 | 748 | 161 | 1 853 | 4.6× | 2.5× |
+| | 512 | 7 179 | 1 292 | 31 386 | 5.6× | 4.4× |
 
-All three scale **linearly**; the ratio to naive is largest on tiny inputs
-(fixed per-op setup dominates) and settles around 2–3× on the dense Lens and
-nested-tree chains as the element work amortises. The sparse-Prism shape holds
-~5× because the miss branch carries inherent per-element plumbing.
+Against the hand-written `naive` baseline all three scale **linearly**: the
+`eo ÷ naive` overhead is largest on tiny inputs (fixed per-op setup dominates) and
+settles around 2–3× on the dense Lens and nested chains as element work amortises;
+the sparse-Prism shape holds ~5× because the miss branch carries inherent
+per-element plumbing.
+
+Against Monocle's equivalent composition EO is **faster at every size**, and the
+lead *widens* as the collection grows (`monocle ÷ eo` rises from ~1.4–2× to
+~4–6×) — opposite to the naive gap, which tightens. Monocle's composed `Traversal`
+scales worse here: the dense Lens chain at 256 is 3 492 ns for EO vs 21 367 for
+Monocle, and the 5-hop tree is 16 655 vs 93 715. EO's flat `MultiFocus[PSVec]`
+focus vector rebuilds in one pass where Monocle threads each element through a
+composed applicative `modifyA`.
 
 Under the hood the carrier pairs an existential leftover with a flat `PSVec`
 focus vector (`Array[AnyRef]` + an `(offset, length)` window), and two internal
@@ -319,13 +331,13 @@ subjects: a normal-depth `Expr` tree, a degenerate deep `Bin` spine, and a
 normal-depth circe `Json` tree (via the universal `Plated[Json]`). The `Plated`
 carrier is PSVec-native, so neither path converts to a `List` and back.
 
-| Op | Subject | eo | monocle | visitor |
-|---|---|--:|--:|--:|
-| `universe` | `Expr` balanced | 113 953 | 1 702 000 | 55 248 |
-| | `Json` balanced | 198 254 | 2 051 033 | 130 461 |
-| | `Bin` deep spine | 121 068 | **SO** | 60 927 |
-| `transform` | `Expr` balanced | 153 129 | 184 118 | 73 443 |
-| | `Bin` deep spine | 132 753 | **SO** | 44 744 |
+| Op | Subject | eo | monocle | visitor | eo ÷ visitor |
+|---|---|--:|--:|--:|--:|
+| `universe` | `Expr` balanced | 113 953 | 1 702 000 | 55 248 | 2.1× |
+| | `Json` balanced | 198 254 | 2 051 033 | 130 461 | 1.5× |
+| | `Bin` deep spine | 121 068 | **SO** | 60 927 | 2.0× |
+| `transform` | `Expr` balanced | 153 129 | 184 118 | 73 443 | 2.1× |
+| | `Bin` deep spine | 132 753 | **SO** | 44 744 | 3.0× |
 
 (ns/op at n=512, from the reproducible CI benchmarks workflow — 3-fork on the
 shared runner, so absolute numbers run higher than a quiet desktop; the ratios are

--- a/site/docs/optics.md
+++ b/site/docs/optics.md
@@ -67,9 +67,10 @@ selected by `F`. The full cell-by-cell composition matrix lives in
 ```scala mdoc:silent
 import dev.constructive.eo.optics.{Lens, Optic}
 import dev.constructive.eo.optics.Optic.*
-import dev.constructive.eo.data.Forget.given       // ForgetfulFunctor / Fold / Traverse for Forget[F] carriers
-// (Accessor[Direct] etc. now resolve via `object Direct`'s companion scope — `Direct`
-//  is an opaque type, so no `import Direct.given` is needed for `.get` on Iso / Getter.)
+// `Fold.apply` / `.select` now return the concrete `ForgetFold`, whose eager `foldMap`
+// member needs no `import Forget.given` — the carrier's `ForgetfulFold` is no longer summoned.
+// (Accessor[Direct] etc. resolve via `object Direct`'s companion scope — `Direct` is an
+//  opaque type, so no `import Direct.given` is needed for `.get` on Iso / Getter.)
 ```
 
 Every page here shows optics constructed by hand. For the


### PR DESCRIPTION
## Summary

Three threads, all around the benchmark story:

1. **`ForgetFold` eager `foldMap` (core).** `Fold.apply` / `Fold.select` now return a concrete `ForgetFold` subclass with an eager `foldMap(f)(s): M` member that folds straight through the captured `Foldable[F]` — no `ForgetfulFold[Forget[F]]` carrier summon, no intermediate `S => M` closure. Mirrors the `GetReplaceLens` / `SetterOptic` / `MultiFocusSingleton` specialisations.

2. **Benchmark doc tone reframe.** The narrative now centers the **hand-written / naive baseline** instead of crowing about Monocle. Monocle stays in the tables as a peer reference; where it is genuinely faster (deep Lens modify, single-hit Optional/Getter leaf) we state it and explain the trade-off (generic existential carrier vs purpose-built case classes).

3. **Full table refresh from CI.** Every page table re-sourced from a reproducible `benchmarks.yml` batch (ForgetFold branch + main), each table internally consistent from one run.

## The ForgetFold result (measured on CI)

EO `Fold.foldMap` went from ~5× slower than Monocle to **dead-even**:

| FoldMap | old eo | new eo | Monocle |
|---|--:|--:|--:|
| size 8 | 109.4 | **20.1** | 20.4 |
| size 64 | 932.4 | **325.0** | 307.1 |
| size 512 | 8007.9 | **4535.0** | 4494.7 |

The old overhead was a per-**call** constant (carrier summon + `S⇒B` closure + box/unbox), **not** per-element — so it dominated small folds and faded on large ones. It was invisible to `-prof gc` (both sides were always allocation-identical at 14 080 B/op @512; escape analysis elides the closure, so the cost was *cycles, not bytes*) and to a noisy local box — only CI's low-noise timing resolves it. This also corrects the doc's false "`Forget[F]` adds a per-element dispatch layer" claim: the per-element loops are byte-identical (both end in `cats.Foldable[List].foldMap`).

## Validation

- All Fold laws + full `sbt test` (166 core/tests, 10 generics) pass; member dispatch confirmed (removing the carrier `given` import only warns unused, never missing-instance).
- mdoc + laikaSite clean (the `optics.md` Fold example no longer needs `import Forget.given`).
- Tables refreshed from runs 27142643426 (Fold, branch), 27144992548 (Lens/Prism/Iso/Traversal, branch), 27139356899 (everything else, main).

## Notable table movements

- **avro**: `naive`/`monocle` fell 30–40%, so EO's edge is now ~5–7× on the array write (was ~9×) and ~3 800× on the size-512 read (was ~6 800×).
- **circe**: `eo` scalar ~1.27 → ~1.05 µs; the `Ior` surface overhead has effectively vanished on the scalar path.
- **Plated**: replaced the old *local-box* "indicative" figures with canonical CI numbers (Monocle ~10–15× slower on `universe`, still `StackOverflowError` on the deep spine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-ups (PowerSeries + Plated)

**PowerSeries benches are not EO-only.** `lens.andThen(traversal).andThen(lens)`, `traversal.andThen(prism)`, and nested traversals are first-class in Monocle, so the old "no Monocle equivalent" framing was wrong. Added a `monocle_*` peer to all three composition benches (built from the same chain, with a `@Setup` correctness guard asserting eo == monocle == naive) and the `monocle` / `monocle ÷ eo` columns to the doc table.

Result (CI run 27147617920): **EO is faster than Monocle at every size, and the lead widens with the collection** — `monocle ÷ eo` goes from ~1.4–2× at small N to ~4–6× at the largest (e.g. dense Lens chain at 256: EO 3 492 ns vs Monocle 21 367; 5-hop tree at 256: 16 655 vs 93 715). Monocle's composed `Traversal` threads each element through an applicative `modifyA`, where EO's flat `MultiFocus[PSVec]` rebuilds in one pass.

**Plated table** now carries an `eo ÷ visitor` ratio column (2.1 / 1.5 / 2.0 / 2.1 / 3.0×) so the hand-written-baseline comparison is explicit.
