### PR TITLE
feat(build): mutation testing + QA reporting infrastructure

### DIFF
--- a/.claude/skills/improve-test-leverage/SKILL.md
+++ b/.claude/skills/improve-test-leverage/SKILL.md
@@ -327,7 +327,7 @@ Present before/after:
 | Mutation score (covered)  | 73.6%  | 80.1% | +6.5%  |
 | Surviving mutants         | 53     | 31    | -22    |
 | Statement coverage (pkg)  | 81.9%  | 84.2% | +2.3%  |
-| Test LINES added          | —      | 38    | 22 kills / 38 lines |
+| Test code lines added (scalafmt-normalized, comment-free)          | —      | 38    | 22 kills / 38 lines |
 
 ### Artifacts added (kills per line is the headline)
 1. checkAll PSVec MultiFocus @ biased sizes — 9 mutants, 4 lines
@@ -364,8 +364,22 @@ suite_kill_density = total_detected_mutants / total_test_LOC   (must rise monoto
   and laws at once — count both).
 - `new_branches_covered` — `<statement branch="true">` elements flipping to
   `invocation-count > 0` in the scoverage aggregate.
-- `net_test_lines_added` — net added lines under `*/src/test/**.scala` from
-  `git diff --numstat` (consolidation makes this negative — that's the point).
+- `net_test_lines_added` — net added **code** lines under
+  `*/src/test/**.scala`: count **after formatting** (`sbt scalafmtAll`) and
+  **exclude comments and blank lines**. scalafmt is the arbiter of what "a
+  line of code" is — the two normalizations close both gaming vectors
+  (raw-numstat counting punishes documentation: a `// covers:` comment must
+  never make an artifact look worse; pre-format counting rewards cramming
+  statements onto one line). Format first, then:
+
+  ```sh
+  git diff -- '*/src/test/*.scala' \
+    | grep -E '^[+-][^+-]' \
+    | grep -vE '^[+-]\s*(//|\*|/\*\*|\*/|$)' \
+    | awk '/^\+/{a++} /^-/{r++} END{print a-r}'
+  ```
+
+  Consolidation makes this negative — that's the point.
 
 Mutants are keyed by `(file, line, mutatorName, replacement)` — report ids are
 NOT stable across runs.
@@ -415,7 +429,9 @@ clean attribution requires never batching two candidates into one eval.
    - re-run stryker for **every module the candidate claims kills in**
      (borrow sets for core/laws — see step 1);
    - diff the new `report.json` against state by mutant key → `measured_kills`;
-   - `git diff --numstat -- '*/src/test/*'` → `net_test_lines_added`.
+   - run `sbt scalafmtAll` on the touched test files, then count
+     `net_test_lines_added` with the comment/blank-excluding diff from the
+     Objective section (scalafmt-normalized code lines, never raw numstat).
 4. **Accept or revert**:
    - **Accept** if `measured_kills ≥ 1` and `lines/kill ≤ 8`, or
      `net_test_lines_added < 0` with zero kill regression (consolidation).

--- a/.claude/skills/improve-test-leverage/SKILL.md
+++ b/.claude/skills/improve-test-leverage/SKILL.md
@@ -31,6 +31,12 @@ Two structural facts drive everything:
 **Announce at start:** "I'm using the improve-test-leverage skill to analyze
 and improve the test suite's kill capacity."
 
+**Aliases:** `/test-upgrade` (ADD moves only, highest tier first),
+`/test-fix` (gap-closing: candidates ranked by measured Survived /
+NoCoverage clusters), `/test-prune` (CONSOLIDATE only: shrink LOC at
+held kills). Each is a thin skill that delegates here with the move bias
+pre-set; arguments pass through.
+
 **Two modes:**
 
 - **Guided (default)** — the 10-step workflow below: one planned batch,

--- a/.claude/skills/improve-test-leverage/SKILL.md
+++ b/.claude/skills/improve-test-leverage/SKILL.md
@@ -1,0 +1,492 @@
+---
+name: improve-test-leverage
+description: Orchestrates a coverage + mutation improvement cycle tuned to cats-eo's algebraic structure. Reads scoverage + stryker4s reports, triages surviving mutants, and plans the minimum set of law registrations / negative fixtures / properties that maximizes mutants killed per test line, exploiting the centralized tests/ module that scores core AND laws simultaneously. Supports a measured eval-optimization loop ("loop" argument) that iterates candidate→measure→accept/revert against an explicit kills-per-line objective until budget or convergence, and a user-gated law-promotion path that elevates universal properties (associativity, identity, fusion) into the published cats-eo-laws artifact for clients.
+model: sonnet
+---
+
+# Improve Test Leverage
+
+## Overview
+
+This skill runs a complete test-quality improvement cycle for cats-eo. It is
+the algebraic adaptation of a per-module coverage skill: instead of asking
+"which example test kills this mutant?", it asks **"which law, registered
+against which instance, kills the largest family of mutants?"** — and places
+each test where one line of test code scores against the most modules.
+
+Two structural facts drive everything:
+
+1. **The leverage hierarchy is algebraic.** A Discipline ruleset registration
+   (`checkAll`) is ~5–15 properties in one line; a law over a *composed* optic
+   exercises two families plus the compose machinery; a single `forAll`
+   property beats N examples. Example-based tests are the floor, not the
+   default.
+2. **Test placement is attribution.** The `tests/` module's suite is
+   task-borrowed into both `core`'s and `laws`' mutation runs (see
+   `mutationAll` in build.sbt), and scoverage aggregates cross-module. So a
+   law registration in `tests/` kills mutants in core AND laws AND raises
+   coverage everywhere it reaches — while a spec in `schemes/src/test` is the
+   only thing that can kill a schemes mutant. Put the test where it scores.
+
+**Announce at start:** "I'm using the improve-test-leverage skill to analyze
+and improve the test suite's kill capacity."
+
+**Two modes:**
+
+- **Guided (default)** — the 10-step workflow below: one planned batch,
+  user-confirmed, executed, verified, reported.
+- **Eval-optimization loop** (`/improve-test-leverage loop [N iterations |
+  module focus]`) — autonomous iterate-measure-accept/revert against the
+  explicit objective in [the loop section](#eval-optimization-loop-mode).
+  Steps 1–3 (reports, table, triage) still run first to build the candidate
+  pool; steps 4–10 are replaced by the loop. Get user confirmation ONCE on
+  the objective, budget, and candidate pool — then iterate without per-batch
+  confirmation. Sole exception: the
+  [law-promotion gate](#law-promotion-intervention-point) always stops for
+  the user.
+
+## Workflow
+
+```dot
+digraph leverage_workflow {
+    rankdir=TB;
+    node [shape=box];
+
+    reports [label="1. Generate / reuse scoverage + stryker reports"];
+    table [label="2. Present per-module table\n(QA page is the dashboard)"];
+    triage [label="3. Triage surviving mutants\nby leverage tier + placement"];
+    plan [label="4. Plan mode: minimal high-leverage test set"];
+    review [label="5. Adversarial self-review:\ncan a law replace each property?"];
+    confirm [label="6. User confirmation" shape=diamond];
+    execute [label="7. Write tests (CheckAllHelpers conventions)"];
+    verify [label="8. sbt test + re-run affected mutation targets"];
+    consolidate [label="9. Consolidate: laws subsume examples"];
+    report [label="10. Before/after report + regenerate QA page"];
+
+    reports -> table -> triage -> plan -> review -> confirm;
+    confirm -> execute [label="confirmed"];
+    confirm -> plan [label="revise"];
+    execute -> verify -> consolidate -> report;
+}
+```
+
+## Step 1: Generate or Reuse Reports
+
+Reports are expensive (~15–25 min for the full sweep). **Reuse them if fresh**
+— same branch, no main-source changes since they were written:
+
+- Coverage aggregate: `target/scala-*/scoverage-report/scoverage.xml`
+- Mutation, per module: `<module>/target/stryker4s-report/<timestamp>/report.json`
+  (schema v2: `files{}.mutants[].status` ∈ Killed / Timeout / Survived /
+  NoCoverage / CompileError / Ignored)
+
+To regenerate:
+
+```sh
+SBT_OPTS="-Xmx6g -Xss8m" sbt coverageAll     # cross-module aggregate
+SBT_OPTS="-Xmx6g -Xss8m" sbt mutationAll     # all scoreable modules
+```
+
+Both aliases relax `-Werror` and need the big heap (the `set` reapply
+re-evaluates the Laika docs settings). `mutationAll` already contains the
+core/laws borrow `set`s and stops at avro's known failure — that's expected.
+
+**Re-running a single module** (after writing tests, step 8):
+
+```sh
+# schemes / circe — module-local suites:
+SBT_OPTS="-Xmx6g -Xss8m" sbt -batch 'set ThisBuild/tlFatalWarnings := false' \
+  'project schemes' stryker
+
+# core or laws — MUST include the borrow sets or every mutant is NoCoverage:
+SBT_OPTS="-Xmx6g -Xss8m" sbt -batch 'set ThisBuild/tlFatalWarnings := false' \
+  'set LocalProject("core")/Test/definedTests ++= (LocalProject("tests")/Test/definedTests).value' \
+  'set LocalProject("core")/Test/fullClasspath ++= (LocalProject("tests")/Test/fullClasspath).value' \
+  'project core' stryker
+```
+
+Never use `<module>/stryker` (module-scoped task form) — it resolves test
+frameworks from the root project and reports 100% NoCoverage. Always
+`project <m>; stryker`.
+
+### Module caveats (do not fight these)
+
+| Module | Status | Why |
+|---|---|---|
+| `core`, `laws` | scored via borrowed `tests/` suite | task-level borrowing; see build.sbt `mutationAll` comment |
+| `generics` | structurally unscoreable (0%) | macro code expands at compile time — no runtime mutants. Guarded by the law specs in `generics/test`; skip it here |
+| `avro` | not scored | stryker's forked test-runner fails to initialise in its sandbox (specs pass under plain `sbt test`) |
+| `jsoniter` | check current QA page | historically blocked: instrumenting `PathParser.parseField` overflowed the JVM 64 KB method limit |
+| all | StringLiteral mutants excluded build-wide | error messages / labels / rule-set names — unkillable noise (`ThisBuild / strykerExcludedMutations`) |
+| all | CompileError mutants are normal | `-Yexplicit-nulls` flow-typing rejects some null-check mutations; stryker marks and continues. Do NOT strip the flag — these are excluded from the score |
+
+## Step 2: Present the Module Table
+
+The QA page (`site/docs/quality-assurance.md`) already holds the generated
+per-package coverage table (with BC/SC ratio) and the per-module mutation
+table — `site/tools/gen-qa-report.py` parses the same reports this skill
+reads. Present those numbers (regenerate the page first if reports are newer)
+and ask which module / mutant cluster to attack, unless the user already said.
+
+## Step 3: Triage Surviving Mutants by Leverage
+
+Read the chosen module's `report.json`. For each Survived / NoCoverage mutant
+collect: mutator type, file:line, original vs replacement, and enough
+surrounding source to judge what behaviour changed. Then sort into the
+**leverage tiers** — for each mutant, the question is not "what test kills
+this?" but "what is the most algebraic artifact that kills this *and its
+neighbors*?":
+
+| Tier | Artifact | Kill profile | When |
+|---|---|---|---|
+| 0 | **Law promotion** — a NEW law added to `cats-eo-laws` + its Discipline ruleset (requires the [user gate](#law-promotion-intervention-point)) | one law method × EVERY existing `checkAll` registration repo-wide, then ships to clients in the published `cats-eo-laws` artifact | a candidate property is *universal* for an abstraction (associativity, identity, fusion, naturality) — not specific to one instance |
+| 1 | **Law-ruleset registration** — `checkAll` via `CheckAllHelpers` against an instance/carrier/arity not yet covered | one line ≈ 5–15 properties; kills whole branches of the instance's code paths | the mutant sits on a code path any existing law exercises, just not for this instance shape |
+| 2 | **Composed-optic law registration** — laws on `outer.andThen(inner)` for an uncovered family pair | kills in BOTH component families plus the compose/carrier machinery | the mutant is in `compose`/carrier dispatch or only reachable through composition |
+| 3 | **Negative fixture** — a deliberately unlawful instance asserted to FAIL specific laws | the ONLY killer of law-WEAKENING mutants in `laws` (guard → `false`, `&&` → `\|\|`): every lawful instance satisfies the weakened law too | the mutant is in `laws/` law bodies and survived the borrowed suite |
+| 4 | **Targeted property** (`forAll`) | one property ≈ N examples; needed where laws don't reach (machinery internals, boundaries) | e.g. schemes' fold-machine: size generators must *straddle* thresholds like `OnStackLimit` so both branches of `depth >= limit` execute with observable difference |
+| 5 | **Example test** | one kill each — the floor | fixed constants, lifecycle, or a single semantically-distinct input |
+
+Also mark **equivalent mutants** (behaviour provably unchanged — e.g. an
+`eq`-identity fast-path whose slow path computes the same result) and
+**wrong-module mutants**: a NoCoverage mutant in core whose only natural
+exercise is a schemes/circe code path can be left to scoverage (the aggregate
+already counts cross-module coverage) — note it instead of forcing an
+artificial test into `tests/`.
+
+**Placement rule** (decides where each artifact lives):
+
+- Mutant in `core` or `laws` → write in `tests/` (scores against both via
+  borrowing; one artifact can kill in core and laws at once).
+- Mutant in `schemes` / `circe` / `jsoniter` → write in that module's own
+  `src/test` (its stryker run sees nothing else).
+- Never write the same exercise twice in two places; prefer the placement
+  with the larger blast radius.
+
+## Step 4: Plan the Minimal Set (Plan Mode)
+
+Enter plan mode. Output a table — one row per artifact, not per assertion:
+
+```
+| # | Artifact | Tier | File | Mutants killed (ids/lines) | Why this beats alternatives |
+|---|----------|------|------|----------------------------|-----------------------------|
+| 1 | PSVec MultiFocus laws @ size-0/1/many | 1 | tests/.../OpticsLawsSpec.scala | ~9 in data/PSVec | one checkAll vs 9 examples |
+| 2 | Unlawful AffineFold fixture fails missIsEmpty | 3 | tests/.../UnlawfulFixturesSpec.scala | laws:41 guard→false | only negative fixture can kill weakening |
+```
+
+For each row include: generators needed (with the *distribution* argument —
+e.g. "sizes biased to {0, 1, OnStackLimit−1, OnStackLimit, OnStackLimit+1}"),
+the law/property statement, and the named mutants it kills with the causal
+chain (mutant flips X → law Y's equality fails on input class Z).
+
+## Step 5: Adversarial Self-Review
+
+Before presenting, challenge every row (dispatch a review subagent for large
+plans):
+
+1. Any Tier-4/5 row that restates an existing law → replace with a Tier-1
+   registration of that law.
+2. Any generator whose distribution can't actually reach the mutated branch
+   (the most common silent failure — e.g. default `Gen.listOf` almost never
+   produces lists longer than a stack threshold).
+3. Negative fixtures must be *minimally* unlawful: break exactly the clause
+   the mutant weakens, keep everything else lawful, otherwise the fixture
+   can't distinguish the weakened law from the original.
+4. Each claimed kill must name the assertion that fails under the mutant.
+
+## Law-Promotion Intervention Point
+
+While triaging or self-reviewing, a Tier-4 property sometimes turns out not to
+be a test at all — it's a **missing law**. Telltales:
+
+- It quantifies over *all* instances of a family/typeclass, not one fixture —
+  e.g. `andThen` associativity (`(a ∘ b) ∘ c` ≅ `a ∘ (b ∘ c)` at both the
+  carrier and read/write level), composition identities against `Iso.id`,
+  fusion equalities, naturality of a carrier transformation.
+- Several specs each verify the same shape ad-hoc for their own instance.
+- The algebra demands it: the composition matrix is a category — where are
+  its associativity and identity witnesses? A carrier with `map` is a functor
+  — does anything pin composition?
+
+**This is a user decision, never autonomous.** A law is a public contract:
+clients will check THEIR instances against it via the published
+`cats-eo-laws` artifact. Before asking, do the homework:
+
+1. **State it formally** — name, signature, the equality it asserts, and
+   which existing laws (if any) nearly-imply it. If it is *derivable* from
+   existing laws, it is redundant — don't propose it.
+2. **Counterexample search** — run the candidate as a scratch `forAll`
+   against EVERY instance shape currently registered in the repo's
+   `checkAll` sites. A failure means either it's not a law or an instance is
+   unlawful — both findings go to the user verbatim, not silently dropped.
+3. **Estimate the blast radius** — which existing registrations would inherit
+   it (= predicted kills), and what clients gain.
+
+Then ask the user (AskUserQuestion), presenting: the formal statement, the
+evidence (N instance shapes × M samples, zero counterexamples), placement,
+predicted kills, and the options **promote** / **keep as tests/-only
+property** / **reject**. The user is the judge of *validity* (universally
+true for the abstraction, not incidentally true for today's instances) and
+*worth* (is this a contract we want to maintain forever?).
+
+**On approval, promotion mechanics:**
+
+1. Law method → the matching trait in `laws/src/main/scala/.../laws/`
+   (family laws at the root, `laws.data` for carriers, `laws.typeclass` for
+   typeclasses, `laws.eo` for EO-specific structure). Scaladoc states the
+   equality and why it holds.
+2. Ruleset wiring → the corresponding `*Tests` class in the sibling
+   `.discipline` package. Every existing `checkAll` call site inherits the
+   new property with **zero test-file changes** — that's the Tier-0 payoff.
+3. `sbt test` — if a previously-registered instance now FAILS, stop: either
+   the law is wrong or the instance is unlawful. Back to the user.
+4. `sbt mimaReportBinaryIssues` — `cats-eo-laws` is published; adding
+   concrete trait methods is normally compatible, but verify (vacuous before
+   0.1.1, load-bearing after).
+5. Re-run mutation for the affected modules — the promotion's kills are
+   measured like any other candidate.
+6. Surface the new law in the docs (the laws listing the site documents) so
+   clients can find it.
+
+## Step 6: User Confirmation
+
+Present the plan (artifact table + expected kill count + before-numbers).
+Wait for explicit confirmation.
+
+## Step 7: Execute
+
+Conventions (read a neighbor spec first; these are the load-bearing ones):
+
+- **Framework**: specs2 `mutable.Specification`; law registrations via
+  `CheckAllHelpers` (mixes in Discipline; helpers return `Fragment` to
+  silence `-Wnonunit-statement`). Add a `// covers: ...` comment at each
+  `checkAll` call site — that's the established audit convention.
+- **Generators**: `Arbitrary`/`Cogen` given instances near the spec (see
+  `OpticsLawsSpec`), shared fixtures in `Samples.scala` / `examples/`.
+- **Negative fixtures**: instantiate the law trait directly with the broken
+  instance and assert the law method returns `false` on a witness input —
+  e.g. `new AffineFoldLaws[S, A] { def af = brokenAffineFold }
+  .missIsEmpty(missInput, f) must beFalse`. Pin the witness input as a
+  constant with a comment naming the mutant it kills; do NOT register
+  negative fixtures through `checkAll` (Discipline expects laws to pass).
+- **schemes machinery properties**: structures must straddle the documented
+  thresholds (`OnStackLimit`); assert results, not timing.
+- **No mocks** anywhere in this codebase; everything is pure data.
+- Format before committing: `sbt "scalafixAll; scalafmtAll"` (the sbt form,
+  NOT the CLI scalafmt — they diverge; pre-commit gates on the sbt form).
+
+## Step 8: Verify
+
+```sh
+sbt test                                  # full root aggregate must pass
+# then re-run mutation ONLY for the modules whose mutants you targeted,
+# using the step-1 single-module commands (borrow sets for core/laws!)
+```
+
+Compare each targeted mutant's status in the new `report.json` against the
+plan's claims. A claimed kill that still survives means the generator never
+reached the branch or the assertion is too weak — fix it now; do not move on.
+
+## Step 9: Consolidate
+
+The eo consolidation rule is stronger than "one property per method":
+**no test may restate what a law already says.**
+
+1. A property that is an instance of an existing law → delete it, register
+   the law (Tier 1) instead.
+2. \>1 example on the same code path → one property whose generator spans the
+   input categories (encode expected outcomes in the generated scenario when
+   categories are finite; keep the assertion a bare invariant when it's
+   universal).
+3. Two properties asserting different facets of one operation → merge.
+4. Keep negative fixtures separate and explicit — they are documentation of
+   the laws' discriminating power, one fixture per weakened clause.
+
+After consolidating, re-run the affected mutation targets; if the score
+regressed, a deleted test was the sole killer of some mutant — restore that
+exercise.
+
+## Step 10: Report + Refresh the QA Page
+
+```sh
+python3 site/tools/gen-qa-report.py        # rewrites the generated tables
+```
+
+Present before/after:
+
+```
+## Test-leverage improvement: <module(s)>
+
+| Metric                    | Before | After | Change |
+|---------------------------|--------|-------|--------|
+| Mutation score (covered)  | 73.6%  | 80.1% | +6.5%  |
+| Surviving mutants         | 53     | 31    | -22    |
+| Statement coverage (pkg)  | 81.9%  | 84.2% | +2.3%  |
+| Test LINES added          | —      | 38    | 22 kills / 38 lines |
+
+### Artifacts added (kills per line is the headline)
+1. checkAll PSVec MultiFocus @ biased sizes — 9 mutants, 4 lines
+2. UnlawfulFixturesSpec (2 fixtures) — 3 mutants, 18 lines
+...
+
+### Remaining survivors (documented, not chased)
+- N equivalent mutants (identity fast-paths) — listed with justification
+- M mutants only reachable from <other module> — covered by aggregate scoverage
+```
+
+The QA page diff (regenerated tables) ships with the PR so the docs stay
+truthful.
+
+## Eval-Optimization Loop Mode
+
+The loop turns the guided workflow into a measured optimizer. Nothing is
+"improved" by assertion: every iteration's value is *measured* by re-running
+the evals, and candidates that don't pay for their lines are reverted.
+
+### Objective
+
+Maximize repo-wide **kill density**, with branch coverage as the secondary
+term:
+
+```
+iteration_leverage = (new_kills + new_branches_covered) / max(1, net_test_lines_added)
+
+suite_kill_density = total_detected_mutants / total_test_LOC   (must rise monotonically)
+```
+
+- `new_kills` — mutants whose status flips Survived/NoCoverage → Killed/Timeout,
+  summed across ALL scoreable modules (a `tests/` artifact can score in core
+  and laws at once — count both).
+- `new_branches_covered` — `<statement branch="true">` elements flipping to
+  `invocation-count > 0` in the scoverage aggregate.
+- `net_test_lines_added` — net added lines under `*/src/test/**.scala` from
+  `git diff --numstat` (consolidation makes this negative — that's the point).
+
+Mutants are keyed by `(file, line, mutatorName, replacement)` — report ids are
+NOT stable across runs.
+
+### State
+
+Keep loop state in `target/test-leverage/state.json` (gitignored via
+`target/`):
+
+```json
+{
+  "baseline": {"per_module_status_counts": {}, "branch_covered": 0, "test_loc": 0},
+  "iterations": [
+    {"n": 1, "candidate": "checkAll PSVec MultiFocus @ biased sizes",
+     "predicted_kills": 9, "measured_kills": 7, "lines": 4,
+     "verdict": "accepted", "commit": "<sha>"}
+  ],
+  "do_not_retry": ["<candidate descriptions that failed measurement>"],
+  "classified_out": [{"key": "...", "reason": "equivalent: eq fast-path"}]
+}
+```
+
+### Loop body
+
+Each iteration is **one candidate**, smallest first within the highest tier —
+clean attribution requires never batching two candidates into one eval.
+
+1. **Pick** the highest `predicted_leverage = predicted_kills / estimated_lines`
+   candidate from the triage pool, skipping `do_not_retry`. Moves available:
+   - **ADD** an artifact (tiers 1–5, placement rule applies);
+   - **CONSOLIDATE** (replace examples with a law registration / merge
+     properties — kills must hold, lines drop);
+   - **PROMOTE-LAW** (tier 0): the loop PAUSES — this move always passes
+     through the [law-promotion gate](#law-promotion-intervention-point),
+     including the counterexample search, before any edit. On approval the
+     promotion is implemented and evaluated like any candidate, with its
+     `laws/src/main` + discipline lines counted in the denominator (the
+     repo-wide kill multiplication normally dwarfs them). On "keep as
+     tests/-only", downgrade to a Tier-4 ADD; on reject, record in
+     `do_not_retry`.
+   - **CLASSIFY-OUT** (mark a mutant equivalent or wrong-module with a one-line
+     justification — shrinks the pool, costs nothing, never inflates the score).
+2. **Implement** the candidate on a clean working tree (`git status` clean
+   apart from loop work; commit or stash anything else first).
+3. **Eval** (this is the gate, not a formality):
+   - `sbt <affected>/test` — must pass, else fix or revert;
+   - re-run stryker for **every module the candidate claims kills in**
+     (borrow sets for core/laws — see step 1);
+   - diff the new `report.json` against state by mutant key → `measured_kills`;
+   - `git diff --numstat -- '*/src/test/*'` → `net_test_lines_added`.
+4. **Accept or revert**:
+   - **Accept** if `measured_kills ≥ 1` and `lines/kill ≤ 8`, or
+     `net_test_lines_added < 0` with zero kill regression (consolidation).
+   - On accept: `git add` the test files + one small commit
+     (`test(<module>): <candidate> — kills N mutants in M lines`), append the
+     iteration record to state.
+   - On revert: `git checkout -- <touched test files>`, record the candidate
+     in `do_not_retry` WITH the measured outcome (e.g. "predicted 9, measured
+     0 — generator never exceeds OnStackLimit"). A failed measurement is
+     information; keep it.
+5. **Checkpoint** every 3 accepted iterations (and at loop end):
+   `sbt coverageAll` → refresh `new_branches_covered` (per-iteration mutation
+   runs are the fast proxy; NoCoverage→Killed flips co-move with branch
+   coverage, but only the aggregate is the truth), then
+   `python3 site/tools/gen-qa-report.py` so the QA page tracks the loop.
+
+### Stop criteria (whichever fires first)
+
+1. **Budget** — the iteration count / time the user set (default: 5 accepted
+   iterations).
+2. **Convergence** — 2 consecutive reverted iterations: the pool's remaining
+   predictions don't survive measurement.
+3. **Pool exhausted** — every remaining survivor is classified-out
+   (equivalent / wrong-module / needs-negative-fixture-the-user-declined).
+
+### Loop report
+
+On exit, present the trajectory, not just the endpoint:
+
+```
+| Iter | Candidate                          | Pred | Meas | Lines | Leverage | Verdict |
+|------|------------------------------------|-----:|-----:|------:|---------:|---------|
+| 1    | checkAll PSVec MF @ biased sizes   |    9 |    7 |     4 |     1.75 | accept  |
+| 2    | negative fixture missIsEmpty       |    1 |    1 |     9 |     0.11 | accept* |
+| 3    | property: M-machine fresh state    |    4 |    0 |    12 |     0.00 | revert  |
+| 4    | consolidate OpticsBehaviorSpec §3  |    0 |    0 |   -41 |        ∞ | accept  |
+
+suite kill density: 0.041 → 0.052 kills/test-line
+branch coverage:    71.7% → 73.4%
+* negative fixtures are exempt from the lines/kill threshold — they are the
+  only possible killer of law-weakening mutants and double as documentation.
+```
+
+Then finish with the guided workflow's step 10 (QA page regen + PR-ready
+diff). Every accepted commit is already small and attributed, so the loop's
+history reads as its own audit log.
+
+### Loop guardrails
+
+- Never weaken an assertion or delete a test to "free up" lines — the
+  `suite_kill_density` denominator only shrinks via genuine consolidation
+  with held kills (the eval in step 3 enforces this; zero kill regression is
+  measured, not assumed).
+- Never mark a mutant equivalent to dodge a hard test — `classified_out`
+  entries need a justification a reviewer can check.
+- The loop edits ONLY files under `*/src/test/`, with one exception: a
+  user-approved **PROMOTE-LAW** move may touch `laws/src/main` and its
+  `.discipline` package — nothing else. Other main-source changes (e.g.
+  splitting jsoniter's `parseField`) stay out of scope; surface them as
+  follow-ups in the loop report.
+- The loop is autonomous between candidates EXCEPT at the law-promotion gate:
+  proposing a new public law always stops for the user, however high the
+  predicted leverage. Unattended runs (cron, `/loop` overnight) queue
+  promotion candidates in `state.json` (`"pending_promotions"`) and skip to
+  the next move instead of blocking.
+- If running under `/loop` or unattended, the per-iteration commits are the
+  recovery points; state.json names the last completed iteration.
+
+## Error Handling
+
+- `stryker` reports 100% NoCoverage → you used `<m>/stryker` or forgot the
+  borrow sets for core/laws. Re-read step 1.
+- sbt OOM during the runs → you forgot `SBT_OPTS="-Xmx6g -Xss8m"`.
+- `Method too large` during mutant compilation → that module has a giant
+  method (jsoniter's `PathParser.parseField`); record as not-scoreable unless
+  the method gets split. Don't chase it here.
+- avro `InitialTestRunFailedException` in <1s with no test output → the known
+  sandbox/test-runner issue; record and move on.
+- A negative fixture makes an unrelated law fail → the fixture is too broken;
+  re-shape it to violate exactly one clause.

--- a/.claude/skills/improve-test-leverage/SKILL.md
+++ b/.claude/skills/improve-test-leverage/SKILL.md
@@ -379,10 +379,16 @@ suite_kill_density = total_detected_mutants / total_test_LOC   (must rise monoto
     | awk '/^\+/{a++} /^-/{r++} END{print a-r}'
   ```
 
-  Consolidation makes this negative — that's the point.
+  File scaffolding (package/imports/class declaration) of a NEW spec file is
+  excluded — it is fixed infrastructure that would otherwise quantize small
+  artifacts (the first example in a file pays ~7 lines the second doesn't).
+  Measure the example bodies. Consolidation makes this negative — that's the
+  point.
 
-Mutants are keyed by `(file, line, mutatorName, replacement)` — report ids are
-NOT stable across runs.
+Mutants are keyed by `(file, line, COLUMN, mutatorName, replacement)` — report
+ids are not stable across runs, and two mutants on one line can share mutator
+and replacement (e.g. `<` → `>` on both halves of a bounds check), so the
+column is load-bearing in the key.
 
 ### State
 

--- a/.claude/skills/improve-test-leverage/SKILL.md
+++ b/.claude/skills/improve-test-leverage/SKILL.md
@@ -448,11 +448,16 @@ clean attribution requires never batching two candidates into one eval.
      in `do_not_retry` WITH the measured outcome (e.g. "predicted 9, measured
      0 — generator never exceeds OnStackLimit"). A failed measurement is
      information; keep it.
-5. **Checkpoint** every 3 accepted iterations (and at loop end):
-   `sbt coverageAll` → refresh `new_branches_covered` (per-iteration mutation
-   runs are the fast proxy; NoCoverage→Killed flips co-move with branch
-   coverage, but only the aggregate is the truth), then
-   `python3 site/tools/gen-qa-report.py` so the QA page tracks the loop.
+5. **Checkpoint** every 3 accepted iterations (and at loop end). ORDER IS
+   LOAD-BEARING: `coverageAll` begins with `clean`, which DELETES every
+   `stryker4s-report` directory — run the coverage refresh FIRST, then re-run
+   mutation for the loop's touched modules, then
+   `python3 site/tools/gen-qa-report.py`. Regenerating the page after a
+   coverage run without re-running mutation writes "no report" rows over the
+   mutation table. (Two trusted sources per metric: the scoverage aggregate
+   XML's `All done` line is the truth for coverage — per-module log lines
+   are not; per-iteration mutation runs are the fast proxy for branch flips,
+   but only the aggregate is the truth.)
 
 ### Stop criteria (whichever fires first)
 

--- a/.claude/skills/improve-test-leverage/SKILL.md
+++ b/.claude/skills/improve-test-leverage/SKILL.md
@@ -1,525 +1,129 @@
 ---
 name: improve-test-leverage
-description: Orchestrates a coverage + mutation improvement cycle tuned to cats-eo's algebraic structure. Reads scoverage + stryker4s reports, triages surviving mutants, and plans the minimum set of law registrations / negative fixtures / properties that maximizes mutants killed per test line, exploiting the centralized tests/ module that scores core AND laws simultaneously. Supports a measured eval-optimization loop ("loop" argument) that iterates candidate→measure→accept/revert against an explicit kills-per-line objective until budget or convergence, and a user-gated law-promotion path that elevates universal properties (associativity, identity, fusion) into the published cats-eo-laws artifact for clients.
+description: Orchestrates a coverage + mutation improvement cycle tuned to cats-eo's algebraic structure. Reads scoverage + stryker4s reports, triages surviving mutants, and drives every test artifact UP the promotion ladder (examples → property → law) so the suite kills more mutants with FEWER test lines. Phases live in phases/*.md, each with its own model assignment. Mandatory consolidation and law-scan phases close every run; law promotion is user-gated. Supports a measured eval-optimization loop ("loop" argument).
 model: sonnet
 ---
 
 # Improve Test Leverage
 
-## Overview
+The algebraic test-quality cycle for cats-eo. Instead of asking "which example
+test kills this mutant?", it asks **"which law, registered against which
+instance, kills the largest family of mutants?"** — and then asks the harder
+question every run MUST answer: **"which existing tests does that make
+redundant?"**
 
-This skill runs a complete test-quality improvement cycle for cats-eo. It is
-the algebraic adaptation of a per-module coverage skill: instead of asking
-"which example test kills this mutant?", it asks **"which law, registered
-against which instance, kills the largest family of mutants?"** — and places
-each test where one line of test code scores against the most modules.
+## The promotion ladder (the spine of everything)
 
-Two structural facts drive everything:
-
-1. **The leverage hierarchy is algebraic.** A Discipline ruleset registration
-   (`checkAll`) is ~5–15 properties in one line; a law over a *composed* optic
-   exercises two families plus the compose machinery; a single `forAll`
-   property beats N examples. Example-based tests are the floor, not the
-   default.
-2. **Test placement is attribution.** The `tests/` module's suite is
-   task-borrowed into both `core`'s and `laws`' mutation runs (see
-   `mutationAll` in build.sbt), and scoverage aggregates cross-module. So a
-   law registration in `tests/` kills mutants in core AND laws AND raises
-   coverage everywhere it reaches — while a spec in `schemes/src/test` is the
-   only thing that can kill a schemes mutant. Put the test where it scores.
-
-**Announce at start:** "I'm using the improve-test-leverage skill to analyze
-and improve the test suite's kill capacity."
-
-**Aliases:** `/test-upgrade` (ADD moves only, highest tier first),
-`/test-fix` (gap-closing: candidates ranked by measured Survived /
-NoCoverage clusters), `/test-prune` (CONSOLIDATE only: shrink LOC at
-held kills). Each is a thin skill that delegates here with the move bias
-pre-set; arguments pass through.
-
-**Two modes:**
-
-- **Guided (default)** — the 10-step workflow below: one planned batch,
-  user-confirmed, executed, verified, reported.
-- **Eval-optimization loop** (`/improve-test-leverage loop [N iterations |
-  module focus]`) — autonomous iterate-measure-accept/revert against the
-  explicit objective in [the loop section](#eval-optimization-loop-mode).
-  Steps 1–3 (reports, table, triage) still run first to build the candidate
-  pool; steps 4–10 are replaced by the loop. Get user confirmation ONCE on
-  the objective, budget, and candidate pool — then iterate without per-batch
-  confirmation. Sole exception: the
-  [law-promotion gate](#law-promotion-intervention-point) always stops for
-  the user.
-
-## Workflow
-
-```dot
-digraph leverage_workflow {
-    rankdir=TB;
-    node [shape=box];
-
-    reports [label="1. Generate / reuse scoverage + stryker reports"];
-    table [label="2. Present per-module table\n(QA page is the dashboard)"];
-    triage [label="3. Triage surviving mutants\nby leverage tier + placement"];
-    plan [label="4. Plan mode: minimal high-leverage test set"];
-    review [label="5. Adversarial self-review:\ncan a law replace each property?"];
-    confirm [label="6. User confirmation" shape=diamond];
-    execute [label="7. Write tests (CheckAllHelpers conventions)"];
-    verify [label="8. sbt test + re-run affected mutation targets"];
-    consolidate [label="9. Consolidate: laws subsume examples"];
-    report [label="10. Before/after report + regenerate QA page"];
-
-    reports -> table -> triage -> plan -> review -> confirm;
-    confirm -> execute [label="confirmed"];
-    confirm -> plan [label="revise"];
-    execute -> verify -> consolidate -> report;
-}
-```
-
-## Step 1: Generate or Reuse Reports
-
-Reports are expensive (~15–25 min for the full sweep). **Reuse them if fresh**
-— same branch, no main-source changes since they were written:
-
-- Coverage aggregate: `target/scala-*/scoverage-report/scoverage.xml`
-- Mutation, per module: `<module>/target/stryker4s-report/<timestamp>/report.json`
-  (schema v2: `files{}.mutants[].status` ∈ Killed / Timeout / Survived /
-  NoCoverage / CompileError / Ignored)
-
-To regenerate:
-
-```sh
-SBT_OPTS="-Xmx6g -Xss8m" sbt coverageAll     # cross-module aggregate
-SBT_OPTS="-Xmx6g -Xss8m" sbt mutationAll     # all scoreable modules
-```
-
-Both aliases relax `-Werror` and need the big heap (the `set` reapply
-re-evaluates the Laika docs settings). `mutationAll` already contains the
-core/laws borrow `set`s and stops at avro's known failure — that's expected.
-
-**Re-running a single module** (after writing tests, step 8):
-
-```sh
-# schemes / circe — module-local suites:
-SBT_OPTS="-Xmx6g -Xss8m" sbt -batch 'set ThisBuild/tlFatalWarnings := false' \
-  'project schemes' stryker
-
-# core or laws — MUST include the borrow sets or every mutant is NoCoverage:
-SBT_OPTS="-Xmx6g -Xss8m" sbt -batch 'set ThisBuild/tlFatalWarnings := false' \
-  'set LocalProject("core")/Test/definedTests ++= (LocalProject("tests")/Test/definedTests).value' \
-  'set LocalProject("core")/Test/fullClasspath ++= (LocalProject("tests")/Test/fullClasspath).value' \
-  'project core' stryker
-```
-
-Never use `<module>/stryker` (module-scoped task form) — it resolves test
-frameworks from the root project and reports 100% NoCoverage. Always
-`project <m>; stryker`.
-
-### Module caveats (do not fight these)
-
-| Module | Status | Why |
-|---|---|---|
-| `core`, `laws` | scored via borrowed `tests/` suite | task-level borrowing; see build.sbt `mutationAll` comment |
-| `generics` | structurally unscoreable (0%) | macro code expands at compile time — no runtime mutants. Guarded by the law specs in `generics/test`; skip it here |
-| `avro` | not scored | stryker's forked test-runner fails to initialise in its sandbox (specs pass under plain `sbt test`) |
-| `jsoniter` | check current QA page | historically blocked: instrumenting `PathParser.parseField` overflowed the JVM 64 KB method limit |
-| all | StringLiteral mutants excluded build-wide | error messages / labels / rule-set names — unkillable noise (`ThisBuild / strykerExcludedMutations`) |
-| all | CompileError mutants are normal | `-Yexplicit-nulls` flow-typing rejects some null-check mutations; stryker marks and continues. Do NOT strip the flag — these are excluded from the score |
-
-## Step 2: Present the Module Table
-
-The QA page (`site/docs/quality-assurance.md`) already holds the generated
-per-package coverage table (with BC/SC ratio) and the per-module mutation
-table — `site/tools/gen-qa-report.py` parses the same reports this skill
-reads. Present those numbers (regenerate the page first if reports are newer)
-and ask which module / mutant cluster to attack, unless the user already said.
-
-## Step 3: Triage Surviving Mutants by Leverage
-
-Read the chosen module's `report.json`. For each Survived / NoCoverage mutant
-collect: mutator type, file:line, original vs replacement, and enough
-surrounding source to judge what behaviour changed. Then sort into the
-**leverage tiers** — for each mutant, the question is not "what test kills
-this?" but "what is the most algebraic artifact that kills this *and its
-neighbors*?":
-
-| Tier | Artifact | Kill profile | When |
-|---|---|---|---|
-| 0 | **Law promotion** — a NEW law added to `cats-eo-laws` + its Discipline ruleset (requires the [user gate](#law-promotion-intervention-point)) | one law method × EVERY existing `checkAll` registration repo-wide, then ships to clients in the published `cats-eo-laws` artifact | a candidate property is *universal* for an abstraction (associativity, identity, fusion, naturality) — not specific to one instance |
-| 1 | **Law-ruleset registration** — `checkAll` via `CheckAllHelpers` against an instance/carrier/arity not yet covered | one line ≈ 5–15 properties; kills whole branches of the instance's code paths | the mutant sits on a code path any existing law exercises, just not for this instance shape |
-| 2 | **Composed-optic law registration** — laws on `outer.andThen(inner)` for an uncovered family pair | kills in BOTH component families plus the compose/carrier machinery | the mutant is in `compose`/carrier dispatch or only reachable through composition |
-| 3 | **Negative fixture** — a deliberately unlawful instance asserted to FAIL specific laws | the ONLY killer of law-WEAKENING mutants in `laws` (guard → `false`, `&&` → `\|\|`): every lawful instance satisfies the weakened law too | the mutant is in `laws/` law bodies and survived the borrowed suite |
-| 4 | **Targeted property** (`forAll`) | one property ≈ N examples; needed where laws don't reach (machinery internals, boundaries) | e.g. schemes' fold-machine: size generators must *straddle* thresholds like `OnStackLimit` so both branches of `depth >= limit` execute with observable difference |
-| 5 | **Example test** | one kill each — the floor | fixed constants, lifecycle, or a single semantically-distinct input |
-
-Also mark **equivalent mutants** (behaviour provably unchanged — e.g. an
-`eq`-identity fast-path whose slow path computes the same result) and
-**wrong-module mutants**: a NoCoverage mutant in core whose only natural
-exercise is a schemes/circe code path can be left to scoverage (the aggregate
-already counts cross-module coverage) — note it instead of forcing an
-artificial test into `tests/`.
-
-**Placement rule** (decides where each artifact lives):
-
-- Mutant in `core` or `laws` → write in `tests/` (scores against both via
-  borrowing; one artifact can kill in core and laws at once).
-- Mutant in `schemes` / `circe` / `jsoniter` → write in that module's own
-  `src/test` (its stryker run sees nothing else).
-- Never write the same exercise twice in two places; prefer the placement
-  with the larger blast radius.
-
-## Step 4: Plan the Minimal Set (Plan Mode)
-
-Enter plan mode. Output a table — one row per artifact, not per assertion:
+Every test artifact in this repo sits on a ladder, and the skill's job is to
+push artifacts UP it — never to let the suite accumulate at the bottom:
 
 ```
-| # | Artifact | Tier | File | Mutants killed (ids/lines) | Why this beats alternatives |
-|---|----------|------|------|----------------------------|-----------------------------|
-| 1 | PSVec MultiFocus laws @ size-0/1/many | 1 | tests/.../OpticsLawsSpec.scala | ~9 in data/PSVec | one checkAll vs 9 examples |
-| 2 | Unlawful AffineFold fixture fails missIsEmpty | 3 | tests/.../UnlawfulFixturesSpec.scala | laws:41 guard→false | only negative fixture can kill weakening |
+stage 0   example test            (one input, one assertion)
+stage 1   property (forAll)       (one invariant over a generated domain)
+stage 2   ruleset registration    (checkAll — an existing law family applied
+                                   to a new instance via CheckAllHelpers)
+stage 3   LAW in cats-eo-laws     (a new universal property, promoted through
+                                   the user gate; ships to clients)
 ```
 
-For each row include: generators needed (with the *distribution* argument —
-e.g. "sizes biased to {0, 1, OnStackLimit−1, OnStackLimit, OnStackLimit+1}"),
-the law/property statement, and the named mutants it kills with the causal
-chain (mutant flips X → law Y's equality fails on input class Z).
+Two structural facts make the ladder pay:
 
-## Step 5: Adversarial Self-Review
+1. **Each rung multiplies.** A property replaces N examples; a ruleset is
+   ~5–15 properties in one line; a promoted law is inherited by EVERY
+   `checkAll` site in the repo plus every downstream client, with zero
+   test-file changes.
+2. **Placement is attribution.** The `tests/` module is task-borrowed into
+   core's AND laws' mutation runs (`mutationAll` in build.sbt), and scoverage
+   aggregates cross-module — so a high-rung artifact in `tests/` scores
+   everywhere at once, while a `schemes` mutant can only be killed from
+   `schemes/src/test`.
 
-Before presenting, challenge every row (dispatch a review subagent for large
-plans):
+**Announce at start:** "I'm using the improve-test-leverage skill (phase:
+<phase>)."
 
-1. Any Tier-4/5 row that restates an existing law → replace with a Tier-1
-   registration of that law.
-2. Any generator whose distribution can't actually reach the mutated branch
-   (the most common silent failure — e.g. default `Gen.listOf` almost never
-   produces lists longer than a stack threshold).
-3. Negative fixtures must be *minimally* unlawful: break exactly the clause
-   the mutant weakens, keep everything else lawful, otherwise the fixture
-   can't distinguish the weakened law from the original.
-4. Each claimed kill must name the assertion that fails under the mutant.
-
-## Law-Promotion Intervention Point
-
-While triaging or self-reviewing, a Tier-4 property sometimes turns out not to
-be a test at all — it's a **missing law**. Telltales:
-
-- It quantifies over *all* instances of a family/typeclass, not one fixture —
-  e.g. `andThen` associativity (`(a ∘ b) ∘ c` ≅ `a ∘ (b ∘ c)` at both the
-  carrier and read/write level), composition identities against `Iso.id`,
-  fusion equalities, naturality of a carrier transformation.
-- Several specs each verify the same shape ad-hoc for their own instance.
-- The algebra demands it: the composition matrix is a category — where are
-  its associativity and identity witnesses? A carrier with `map` is a functor
-  — does anything pin composition?
-
-**This is a user decision, never autonomous.** A law is a public contract:
-clients will check THEIR instances against it via the published
-`cats-eo-laws` artifact. Before asking, do the homework:
-
-1. **State it formally** — name, signature, the equality it asserts, and
-   which existing laws (if any) nearly-imply it. If it is *derivable* from
-   existing laws, it is redundant — don't propose it.
-2. **Counterexample search** — run the candidate as a scratch `forAll`
-   against EVERY instance shape currently registered in the repo's
-   `checkAll` sites. A failure means either it's not a law or an instance is
-   unlawful — both findings go to the user verbatim, not silently dropped.
-3. **Estimate the blast radius** — which existing registrations would inherit
-   it (= predicted kills), and what clients gain.
-
-Then ask the user (AskUserQuestion), presenting: the formal statement, the
-evidence (N instance shapes × M samples, zero counterexamples), placement,
-predicted kills, and the options **promote** / **keep as tests/-only
-property** / **reject**. The user is the judge of *validity* (universally
-true for the abstraction, not incidentally true for today's instances) and
-*worth* (is this a contract we want to maintain forever?).
-
-**On approval, promotion mechanics:**
-
-1. Law method → the matching trait in `laws/src/main/scala/.../laws/`
-   (family laws at the root, `laws.data` for carriers, `laws.typeclass` for
-   typeclasses, `laws.eo` for EO-specific structure). Scaladoc states the
-   equality and why it holds.
-2. Ruleset wiring → the corresponding `*Tests` class in the sibling
-   `.discipline` package. Every existing `checkAll` call site inherits the
-   new property with **zero test-file changes** — that's the Tier-0 payoff.
-3. `sbt test` — if a previously-registered instance now FAILS, stop: either
-   the law is wrong or the instance is unlawful. Back to the user.
-4. `sbt mimaReportBinaryIssues` — `cats-eo-laws` is published; adding
-   concrete trait methods is normally compatible, but verify (vacuous before
-   0.1.1, load-bearing after).
-5. Re-run mutation for the affected modules — the promotion's kills are
-   measured like any other candidate.
-6. Surface the new law in the docs (the laws listing the site documents) so
-   clients can find it.
-
-## Step 6: User Confirmation
-
-Present the plan (artifact table + expected kill count + before-numbers).
-Wait for explicit confirmation.
-
-## Step 7: Execute
-
-Conventions (read a neighbor spec first; these are the load-bearing ones):
-
-- **Framework**: specs2 `mutable.Specification`; law registrations via
-  `CheckAllHelpers` (mixes in Discipline; helpers return `Fragment` to
-  silence `-Wnonunit-statement`). Add a `// covers: ...` comment at each
-  `checkAll` call site — that's the established audit convention.
-- **Generators**: `Arbitrary`/`Cogen` given instances near the spec (see
-  `OpticsLawsSpec`), shared fixtures in `Samples.scala` / `examples/`.
-- **Negative fixtures**: instantiate the law trait directly with the broken
-  instance and assert the law method returns `false` on a witness input —
-  e.g. `new AffineFoldLaws[S, A] { def af = brokenAffineFold }
-  .missIsEmpty(missInput, f) must beFalse`. Pin the witness input as a
-  constant with a comment naming the mutant it kills; do NOT register
-  negative fixtures through `checkAll` (Discipline expects laws to pass).
-- **schemes machinery properties**: structures must straddle the documented
-  thresholds (`OnStackLimit`); assert results, not timing.
-- **No mocks** anywhere in this codebase; everything is pure data.
-- Format before committing: `sbt "scalafixAll; scalafmtAll"` (the sbt form,
-  NOT the CLI scalafmt — they diverge; pre-commit gates on the sbt form).
-
-## Step 8: Verify
-
-```sh
-sbt test                                  # full root aggregate must pass
-# then re-run mutation ONLY for the modules whose mutants you targeted,
-# using the step-1 single-module commands (borrow sets for core/laws!)
-```
-
-Compare each targeted mutant's status in the new `report.json` against the
-plan's claims. A claimed kill that still survives means the generator never
-reached the branch or the assertion is too weak — fix it now; do not move on.
-
-## Step 9: Consolidate
-
-The eo consolidation rule is stronger than "one property per method":
-**no test may restate what a law already says.**
-
-1. A property that is an instance of an existing law → delete it, register
-   the law (Tier 1) instead.
-2. \>1 example on the same code path → one property whose generator spans the
-   input categories (encode expected outcomes in the generated scenario when
-   categories are finite; keep the assertion a bare invariant when it's
-   universal).
-3. Two properties asserting different facets of one operation → merge.
-4. Keep negative fixtures separate and explicit — they are documentation of
-   the laws' discriminating power, one fixture per weakened clause.
-
-After consolidating, re-run the affected mutation targets; if the score
-regressed, a deleted test was the sole killer of some mutant — restore that
-exercise.
-
-## Step 10: Report + Refresh the QA Page
-
-```sh
-python3 site/tools/gen-qa-report.py        # rewrites the generated tables
-```
-
-Present before/after:
-
-```
-## Test-leverage improvement: <module(s)>
-
-| Metric                    | Before | After | Change |
-|---------------------------|--------|-------|--------|
-| Mutation score (covered)  | 73.6%  | 80.1% | +6.5%  |
-| Surviving mutants         | 53     | 31    | -22    |
-| Statement coverage (pkg)  | 81.9%  | 84.2% | +2.3%  |
-| Test code lines added (scalafmt-normalized, comment-free)          | —      | 38    | 22 kills / 38 lines |
-
-### Artifacts added (kills per line is the headline)
-1. checkAll PSVec MultiFocus @ biased sizes — 9 mutants, 4 lines
-2. UnlawfulFixturesSpec (2 fixtures) — 3 mutants, 18 lines
-...
-
-### Remaining survivors (documented, not chased)
-- N equivalent mutants (identity fast-paths) — listed with justification
-- M mutants only reachable from <other module> — covered by aggregate scoverage
-```
-
-The QA page diff (regenerated tables) ships with the PR so the docs stay
-truthful.
-
-## Eval-Optimization Loop Mode
-
-The loop turns the guided workflow into a measured optimizer. Nothing is
-"improved" by assertion: every iteration's value is *measured* by re-running
-the evals, and candidates that don't pay for their lines are reverted.
-
-### Objective
-
-Maximize repo-wide **kill density**, with branch coverage as the secondary
-term:
+## Objective (all three terms, tracked in state)
 
 ```
 iteration_leverage = (new_kills + new_branches_covered) / max(1, net_test_lines_added)
-
-suite_kill_density = total_detected_mutants / total_test_LOC   (must rise monotonically)
+suite_kill_density = total_detected_mutants / suite_test_code_lines   (must rise)
+suite_test_count   = number of examples + properties                  (net delta ≤ 0 per run)
 ```
 
-- `new_kills` — mutants whose status flips Survived/NoCoverage → Killed/Timeout,
-  summed across ALL scoreable modules (a `tests/` artifact can score in core
-  and laws at once — count both).
-- `new_branches_covered` — `<statement branch="true">` elements flipping to
-  `invocation-count > 0` in the scoverage aggregate.
-- `net_test_lines_added` — net added **code** lines under
-  `*/src/test/**.scala`: count **after formatting** (`sbt scalafmtAll`) and
-  **exclude comments and blank lines**. scalafmt is the arbiter of what "a
-  line of code" is — the two normalizations close both gaming vectors
-  (raw-numstat counting punishes documentation: a `// covers:` comment must
-  never make an artifact look worse; pre-format counting rewards cramming
-  statements onto one line). Format first, then:
+- `net_test_lines_added`: scalafmt-normalized **code** lines (comments/blanks
+  excluded, file scaffolding of new specs excluded). Measurement recipe in
+  [phases/eval.md](phases/eval.md).
+- `suite_test_count` is the metric the first two runs neglected: a run that
+  only ADDs leaves the suite bigger. The mandatory
+  [consolidation phase](phases/consolidate.md) must offset additions —
+  **net example-count growth over a run requires explicit justification in
+  the final report** (legitimate: NoCoverage-dominated pools, negative
+  fixtures, which are documentation).
+- Mutants are keyed `(file, line, column, mutator, replacement)` — column is
+  load-bearing (same-line same-replacement pairs exist).
 
-  ```sh
-  git diff -- '*/src/test/*.scala' \
-    | grep -E '^[+-][^+-]' \
-    | grep -vE '^[+-]\s*(//|\*|/\*\*|\*/|$)' \
-    | awk '/^\+/{a++} /^-/{r++} END{print a-r}'
-  ```
+## Phases
 
-  File scaffolding (package/imports/class declaration) of a NEW spec file is
-  excluded — it is fixed infrastructure that would otherwise quantize small
-  artifacts (the first example in a file pays ~7 lines the second doesn't).
-  Measure the example bodies. Consolidation makes this negative — that's the
-  point.
+Each phase is a file under `phases/`, with the model it should run on. Run
+gates (user confirmation) and accept/revert decisions inline; dispatch
+self-contained phases as subagents with the listed model when the work
+doesn't need the conversation's full context.
 
-Mutants are keyed by `(file, line, COLUMN, mutatorName, replacement)` — report
-ids are not stable across runs, and two mutants on one line can share mutator
-and replacement (e.g. `<` → `>` on both halves of a bounds check), so the
-column is load-bearing in the key.
+| # | Phase | File | Model | Why this model |
+|---|-------|------|-------|----------------|
+| 1 | Reports | [phases/reports.md](phases/reports.md) | haiku | mechanical: run aliases, locate reports, parse |
+| 2 | Triage | [phases/triage.md](phases/triage.md) | sonnet | mutant→tier pattern matching, placement |
+| 3 | Plan + self-review | [phases/plan.md](phases/plan.md) | sonnet | candidate design, generator distributions |
+| 4 | Execute | [phases/execute.md](phases/execute.md) | sonnet | spec writing under repo conventions |
+| 5 | Eval | [phases/eval.md](phases/eval.md) | haiku | mechanical: run, diff by key, count lines |
+| 6 | **Consolidate (mandatory)** | [phases/consolidate.md](phases/consolidate.md) | **opus** | hardest reasoning: proving a property subsumes examples without kill regression |
+| 7 | **Law-scan (mandatory)** | [phases/law-scan.md](phases/law-scan.md) | **opus** | holistic cross-suite generalization; candidate laws need real proofs-of-universality |
+| 8 | Report | [phases/report.md](phases/report.md) | haiku | tables, QA page regen (ORDER: coverage before mutation re-runs — see file) |
 
-### State
+Consolidate and law-scan get the strongest model because they are where the
+user's leverage actually lives — shrinking the suite and minting laws — and
+where a weaker model produces the failure mode the first two runs measured:
+plenty of ADDs, zero reductions, zero law candidates surfaced.
 
-Keep loop state in `target/test-leverage/state.json` (gitignored via
-`target/`):
+## Modes
 
-```json
-{
-  "baseline": {"per_module_status_counts": {}, "branch_covered": 0, "test_loc": 0},
-  "iterations": [
-    {"n": 1, "candidate": "checkAll PSVec MultiFocus @ biased sizes",
-     "predicted_kills": 9, "measured_kills": 7, "lines": 4,
-     "verdict": "accepted", "commit": "<sha>"}
-  ],
-  "do_not_retry": ["<candidate descriptions that failed measurement>"],
-  "classified_out": [{"key": "...", "reason": "equivalent: eq fast-path"}]
-}
-```
+- **Guided (default)**: phases 1→8 in order, one planned batch, user-confirmed
+  at phase 3→4.
+- **Loop** (`loop [N]`): phases 1–3 build the pool; then N accepted
+  iterations of pick→implement→eval (phases 4–5 per candidate); then
+  **phases 6 and 7 run unconditionally** before phase 8. The loop is not
+  done when the budget is spent — it is done when the suite is SMALLER or
+  the report justifies why not.
+  - Iteration moves: ADD (tiers from triage), CLASSIFY-OUT (justified
+    equivalents). CONSOLIDATE is NOT an iteration move — it cannot win a
+    kills-per-line ranking (its kills are zero by definition), which is
+    exactly why the first two runs never picked it. It is phase 6, always.
+  - Accept: `measured_kills ≥ 1` and body-lines/kill ≤ 8. Revert into
+    `do_not_retry` WITH the measured outcome.
+  - Stop: budget; or 2 consecutive reverts; or pool exhausted. Then 6→7→8.
+- **Aliases**: `/test-upgrade` (phases 1–5, ADD-only bias),
+  `/test-fix` (phases 1–5, gap-closing bias), `/test-prune` (phases 1, 6, 8
+  only — pure reduction).
 
-### Loop body
+## State
 
-Each iteration is **one candidate**, smallest first within the highest tier —
-clean attribution requires never batching two candidates into one eval.
+`target/test-leverage/state.json`: baseline (per-module status counts, suite
+test count, suite test LOC), iteration records (candidate, predicted vs
+measured, verdict), `do_not_retry` (with measured outcomes — failed
+predictions are information), `classified_out` (with reviewable
+justifications), `pending_promotions` (law candidates awaiting the user when
+running unattended).
 
-1. **Pick** the highest `predicted_leverage = predicted_kills / estimated_lines`
-   candidate from the triage pool, skipping `do_not_retry`. Moves available:
-   - **ADD** an artifact (tiers 1–5, placement rule applies);
-   - **CONSOLIDATE** (replace examples with a law registration / merge
-     properties — kills must hold, lines drop);
-   - **PROMOTE-LAW** (tier 0): the loop PAUSES — this move always passes
-     through the [law-promotion gate](#law-promotion-intervention-point),
-     including the counterexample search, before any edit. On approval the
-     promotion is implemented and evaluated like any candidate, with its
-     `laws/src/main` + discipline lines counted in the denominator (the
-     repo-wide kill multiplication normally dwarfs them). On "keep as
-     tests/-only", downgrade to a Tier-4 ADD; on reject, record in
-     `do_not_retry`.
-   - **CLASSIFY-OUT** (mark a mutant equivalent or wrong-module with a one-line
-     justification — shrinks the pool, costs nothing, never inflates the score).
-2. **Implement** the candidate on a clean working tree (`git status` clean
-   apart from loop work; commit or stash anything else first).
-3. **Eval** (this is the gate, not a formality):
-   - `sbt <affected>/test` — must pass, else fix or revert;
-   - re-run stryker for **every module the candidate claims kills in**
-     (borrow sets for core/laws — see step 1);
-   - diff the new `report.json` against state by mutant key → `measured_kills`;
-   - run `sbt scalafmtAll` on the touched test files, then count
-     `net_test_lines_added` with the comment/blank-excluding diff from the
-     Objective section (scalafmt-normalized code lines, never raw numstat).
-4. **Accept or revert**:
-   - **Accept** if `measured_kills ≥ 1` and `lines/kill ≤ 8`, or
-     `net_test_lines_added < 0` with zero kill regression (consolidation).
-   - On accept: `git add` the test files + one small commit
-     (`test(<module>): <candidate> — kills N mutants in M lines`), append the
-     iteration record to state.
-   - On revert: `git checkout -- <touched test files>`, record the candidate
-     in `do_not_retry` WITH the measured outcome (e.g. "predicted 9, measured
-     0 — generator never exceeds OnStackLimit"). A failed measurement is
-     information; keep it.
-5. **Checkpoint** every 3 accepted iterations (and at loop end). ORDER IS
-   LOAD-BEARING: `coverageAll` begins with `clean`, which DELETES every
-   `stryker4s-report` directory — run the coverage refresh FIRST, then re-run
-   mutation for the loop's touched modules, then
-   `python3 site/tools/gen-qa-report.py`. Regenerating the page after a
-   coverage run without re-running mutation writes "no report" rows over the
-   mutation table. (Two trusted sources per metric: the scoverage aggregate
-   XML's `All done` line is the truth for coverage — per-module log lines
-   are not; per-iteration mutation runs are the fast proxy for branch flips,
-   but only the aggregate is the truth.)
+## Guardrails
 
-### Stop criteria (whichever fires first)
-
-1. **Budget** — the iteration count / time the user set (default: 5 accepted
-   iterations).
-2. **Convergence** — 2 consecutive reverted iterations: the pool's remaining
-   predictions don't survive measurement.
-3. **Pool exhausted** — every remaining survivor is classified-out
-   (equivalent / wrong-module / needs-negative-fixture-the-user-declined).
-
-### Loop report
-
-On exit, present the trajectory, not just the endpoint:
-
-```
-| Iter | Candidate                          | Pred | Meas | Lines | Leverage | Verdict |
-|------|------------------------------------|-----:|-----:|------:|---------:|---------|
-| 1    | checkAll PSVec MF @ biased sizes   |    9 |    7 |     4 |     1.75 | accept  |
-| 2    | negative fixture missIsEmpty       |    1 |    1 |     9 |     0.11 | accept* |
-| 3    | property: M-machine fresh state    |    4 |    0 |    12 |     0.00 | revert  |
-| 4    | consolidate OpticsBehaviorSpec §3  |    0 |    0 |   -41 |        ∞ | accept  |
-
-suite kill density: 0.041 → 0.052 kills/test-line
-branch coverage:    71.7% → 73.4%
-* negative fixtures are exempt from the lines/kill threshold — they are the
-  only possible killer of law-weakening mutants and double as documentation.
-```
-
-Then finish with the guided workflow's step 10 (QA page regen + PR-ready
-diff). Every accepted commit is already small and attributed, so the loop's
-history reads as its own audit log.
-
-### Loop guardrails
-
-- Never weaken an assertion or delete a test to "free up" lines — the
-  `suite_kill_density` denominator only shrinks via genuine consolidation
-  with held kills (the eval in step 3 enforces this; zero kill regression is
-  measured, not assumed).
-- Never mark a mutant equivalent to dodge a hard test — `classified_out`
-  entries need a justification a reviewer can check.
-- The loop edits ONLY files under `*/src/test/`, with one exception: a
-  user-approved **PROMOTE-LAW** move may touch `laws/src/main` and its
-  `.discipline` package — nothing else. Other main-source changes (e.g.
-  splitting jsoniter's `parseField`) stay out of scope; surface them as
-  follow-ups in the loop report.
-- The loop is autonomous between candidates EXCEPT at the law-promotion gate:
-  proposing a new public law always stops for the user, however high the
-  predicted leverage. Unattended runs (cron, `/loop` overnight) queue
-  promotion candidates in `state.json` (`"pending_promotions"`) and skip to
-  the next move instead of blocking.
-- If running under `/loop` or unattended, the per-iteration commits are the
-  recovery points; state.json names the last completed iteration.
-
-## Error Handling
-
-- `stryker` reports 100% NoCoverage → you used `<m>/stryker` or forgot the
-  borrow sets for core/laws. Re-read step 1.
-- sbt OOM during the runs → you forgot `SBT_OPTS="-Xmx6g -Xss8m"`.
-- `Method too large` during mutant compilation → that module has a giant
-  method (jsoniter's `PathParser.parseField`); record as not-scoreable unless
-  the method gets split. Don't chase it here.
-- avro `InitialTestRunFailedException` in <1s with no test output → the known
-  sandbox/test-runner issue; record and move on.
-- A negative fixture makes an unrelated law fail → the fixture is too broken;
-  re-shape it to violate exactly one clause.
+- Never weaken an assertion or delete a test to shrink the denominator —
+  phase 6's eval re-runs mutation and requires ZERO kill regression,
+  measured, never assumed.
+- Never mark a mutant equivalent to dodge a hard test; justifications must be
+  reviewable.
+- Only `*/src/test/` files change, except a user-approved law promotion
+  (touches `laws/src/main` + its `.discipline` package — see phases/law-scan.md).
+- The law gate ALWAYS stops for the user, in every mode. Unattended runs
+  queue candidates in `pending_promotions` instead of blocking.
+- Timeout-detected kills are run-unstable (measured: one mutant flip-flopped
+  across four consecutive runs) — never count a Timeout flip as a claimed
+  kill; classify the mutant or kill it by value.

--- a/.claude/skills/improve-test-leverage/phases/consolidate.md
+++ b/.claude/skills/improve-test-leverage/phases/consolidate.md
@@ -1,0 +1,50 @@
+# Phase 6 — Consolidate (model: opus — MANDATORY, every run)
+
+The phase the first two runs skipped, and the reason the suite grew when the
+user expected it to shrink. CONSOLIDATE cannot win a kills-per-line ranking
+(its kills are zero by definition), so it must never compete with ADDs — it
+runs unconditionally at the end of every run, in every mode, with the
+strongest available model: proving that a property subsumes a set of examples
+*without kill regression* is the hardest reasoning in this skill.
+
+**The success criterion is dramatic, not cosmetic.** This repo has a
+consolidation culture (`InternalsCoverageSpec` records 25→9 and 9→5 named
+blocks; `JsonFailureSpec` 9→5→1) — match it. A run that added K examples and
+deletes fewer than K has failed this phase unless the report justifies it.
+
+## Procedure
+
+1. **Inventory** every example/property in the affected test files (in a full
+   run: the whole suite, largest files first — `OpticsBehaviorSpec` at ~50K is
+   the standing target). For each: the method/path under test, ladder stage,
+   and the mutants its assertions plausibly kill (from the latest reports).
+2. **Find the folds**, in order of payoff:
+   - **N examples on one code path → 1 property.** The generated scenario can
+     carry both input and expected outcome (`case class Scenario(input, expected)`
+     via `Gen.oneOf` over the categories) when categories are finite; when
+     the assertion is a universal invariant, the invariant IS the property —
+     don't force scenario encoding.
+   - **A property that restates an existing law → delete it, register the
+     ruleset** (stage 1 → stage 2; one `checkAll` line).
+   - **Examples that are specific cases of an existing property → delete.**
+   - **Two properties asserting facets of one operation → merge.**
+   - **Same-shape assertions repeated across instance types → one
+     parameterized helper, or escalate to phase 7 as a law candidate.**
+3. **Keep out of scope**: negative fixtures (one per weakened clause — they
+   are documentation); `// covers:` audit comments (they are why the
+   denominator excludes comments).
+4. **Eval — zero kill regression, measured**: after rewriting, re-run
+   mutation for every affected module (borrow sets for core/laws). ANY
+   mutant that flips Killed→Survived means a deleted test was the sole
+   killer — restore that exercise before proceeding. Then `sbt test` green,
+   `sbt "scalafixAll; scalafmtAll"`.
+5. **Record**: per fold — examples deleted, property created, net lines
+   (negative), kill regression check result. Update `suite_test_count` /
+   `suite_test_loc` in state. Promotions feed the phase 8 report's
+   promotion summary.
+
+## Verdict
+
+Consolidation accepts on `net_test_lines_added < 0` with zero measured kill
+regression. There is no lines/kill ratio here — the leverage is the
+denominator shrinking while kills hold.

--- a/.claude/skills/improve-test-leverage/phases/eval.md
+++ b/.claude/skills/improve-test-leverage/phases/eval.md
@@ -1,0 +1,54 @@
+# Phase 5 — Eval (model: haiku)
+
+The gate, not a formality. Every candidate's value is measured here; nothing
+is accepted on prediction.
+
+## Procedure (per candidate)
+
+1. `sbt <affected>/test` — must pass, else fix or revert.
+2. Re-run stryker for **every module the candidate claims kills in** (exact
+   commands incl. core/laws borrow sets: phases/reports.md).
+3. **Diff the new `report.json` against state by mutant key**
+   `(file, line, column, mutator, replacement)`. Column is load-bearing: two
+   mutants on one line can share mutator AND replacement (both halves of a
+   bounds check mutating to `>`); a line-only key collides and under-reports.
+4. Count `net_test_lines_added`: run `sbt scalafmtAll` on touched test files
+   first, then
+
+   ```sh
+   git diff -- '*/src/test/*.scala' \
+     | grep -E '^[+-][^+-]' \
+     | grep -vE '^[+-]\s*(//|\*|/\*\*|\*/|$)' \
+     | awk '/^\+/{a++} /^-/{r++} END{print a-r}'
+   ```
+
+   scalafmt is the arbiter of what "a line of code" is (raw counting punishes
+   documentation and rewards cramming). File scaffolding
+   (package/imports/class declaration) of a NEW spec file is excluded — fixed
+   infrastructure that would quantize small artifacts. Measure example
+   bodies.
+5. Update `suite_test_count` delta (examples added minus examples deleted).
+
+## Verdict rules
+
+- **Accept**: `measured_kills ≥ 1` and body-lines/kill ≤ 8. Negative
+  fixtures are exempt from the ratio (they are the only possible killer of
+  law-weakening mutants and double as documentation).
+- **Revert**: `git checkout -- <touched test files>`; record in
+  `do_not_retry` WITH the measured outcome ("predicted 9, measured 0 —
+  generator never exceeds OnStackLimit"). A failed measurement is
+  information; keep it.
+- **Timeout flips are not kills.** Timeout-detected mutants oscillate
+  run-to-run (measured across four consecutive runs). A Survived→Timeout
+  flip is recorded as incidental, never claimed; kill by value or classify.
+- On accept: one small commit
+  (`test(<module>): <candidate> — kills N mutants in M lines`), append the
+  iteration record to state.
+
+## Interpreting misses
+
+A claimed kill that still survives means the generator never reached the
+branch, the assertion is too weak, or the line-targeting was wrong (read the
+mutant's column/context again — measured misses corrected the targeting in
+every run so far). Fix or downgrade the claim now; never move on with an
+unexplained miss.

--- a/.claude/skills/improve-test-leverage/phases/execute.md
+++ b/.claude/skills/improve-test-leverage/phases/execute.md
@@ -1,0 +1,34 @@
+# Phase 4 — Execute (model: sonnet)
+
+Write the planned artifacts under repo conventions. Read a neighbor spec
+first; these are the load-bearing rules:
+
+- **Framework**: specs2 `mutable.Specification`; law registrations via
+  `CheckAllHelpers` (mixes in Discipline; helpers return `Fragment` to
+  silence `-Wnonunit-statement`). `// covers: <file:line mutant>` comment at
+  every artifact — the established audit convention.
+- **Generators**: `Arbitrary`/`Cogen` given instances near the spec (see
+  `OpticsLawsSpec`); shared fixtures in `Samples.scala` / `examples/` /
+  `JsonSpecFixtures`-style objects. Distributions must straddle the
+  documented thresholds (builder capacity 16, `transformRecursionLimit` 512,
+  `OnStackLimit`).
+- **Negative fixtures**: instantiate the law trait directly with the broken
+  instance and assert the law method returns `false` on a pinned witness
+  input — never register negative fixtures through `checkAll` (Discipline
+  expects laws to pass). A *stateful* `to` is a legitimate way to be
+  unlawful (purity is an implicit law). Generic-interface corruption can use
+  `null.asInstanceOf` / call-counting when the type system forbids honest
+  corruption — document why.
+- **specs2 implicit pollution**: inside `Prop.forAll`, bind operands to
+  typed vals before `==`, and avoid `.flatten`/`.sum` chains whose implicit
+  evidence search collides with specs2's `ValueCheck` conversions
+  (`xs.map(_.sum).sum` instead of `xs.flatten.sum`).
+- **No mocks** anywhere; everything is pure data. Top-level test ADTs when
+  macros are involved (`new T(...)` loses outer accessors in nested classes).
+- Format before committing: `sbt "scalafixAll; scalafmtAll"` (the sbt form,
+  NOT the CLI scalafmt — they diverge; pre-commit gates on the sbt form).
+- One candidate per commit, message pattern:
+  `test(<module>): <candidate> — kills N mutants in M lines`.
+
+Deletions planned by phase 3's reduction question are executed here too —
+deleting subsumed examples is part of the artifact, not a separate favor.

--- a/.claude/skills/improve-test-leverage/phases/law-scan.md
+++ b/.claude/skills/improve-test-leverage/phases/law-scan.md
@@ -1,0 +1,68 @@
+# Phase 7 — Law-scan (model: opus — MANDATORY, every run; promotion is user-gated)
+
+The holistic pass the first two runs never performed: they only considered
+law promotion opportunistically, per-mutant, and surfaced zero candidates.
+This phase reads ACROSS the whole suite and the algebra, and must end with a
+ranked candidate list — possibly empty, but only with a written justification
+("scanned N property shapes across M files; all instances of existing laws
+because ...").
+
+## Where candidates hide (scan all of these)
+
+1. **Repeated property shapes across instances.** The same `forAll` body
+   appearing for two+ carriers/families, differing only in types, is a law
+   wearing a property costume. (`CheckAllHelpers` exists because the repo
+   already de-duplicated *registrations*; this scan de-duplicates the
+   *statements*.)
+2. **Phase 6 leftovers.** Folds that wanted a parameterized helper across
+   instance types — a helper generic enough to parameterize is usually a law.
+3. **The algebra's unfilled obligations.** The composition matrix is a
+   category: where are associativity (`(a ∘ b) ∘ c ≅ a ∘ (b ∘ c)` at carrier
+   and read/write level) and identity (`Iso.id` composition) witnesses? Every
+   carrier with `map` is a functor — is composition pinned? Fusion equalities
+   the docs assert (`hylo` = `ana` then `cata`)? Naturality of carrier
+   transformations? Check what `cats-eo-laws` ships against what the
+   structures claim, and list the gaps even when no test exists yet.
+4. **Behaviour specs asserting algebra.** `OpticsBehaviorSpec`-style examples
+   that verify `composed.get == inner.get(outer.get(s))` ad-hoc are law
+   instances; the matrix spec pins TYPES, but who pins the SEMANTICS of each
+   composition cell?
+
+## Vetting (before the user sees a candidate)
+
+1. **State it formally**: name, signature, the equality, which existing laws
+   nearly-imply it. Derivable from existing laws → redundant, drop it.
+2. **Counterexample search**: run the candidate as a scratch `forAll` against
+   EVERY instance shape currently registered at any `checkAll` site. A
+   failure is reported verbatim either way — it means not-a-law OR an
+   unlawful instance, and both findings go to the user.
+3. **Blast radius**: which existing registrations inherit it (predicted
+   kills), what clients gain, MiMa impact (`cats-eo-laws` is published —
+   adding concrete trait methods is normally compatible; verify with
+   `mimaReportBinaryIssues`, vacuous before 0.1.1).
+
+## The gate (NEVER autonomous)
+
+Present via AskUserQuestion: formal statement, evidence (N instance shapes ×
+M samples, zero counterexamples), placement, predicted kills, options
+**promote / keep as tests-only property / reject**. The user judges validity
+(universally true for the abstraction, not incidentally true for today's
+instances) and worth (a contract maintained forever). Unattended runs queue
+candidates in state `pending_promotions` and continue.
+
+## On approval — promotion mechanics
+
+1. Law method → the matching trait in `laws/src/main/scala/.../laws/`
+   (family laws at the root, `laws.data` carriers, `laws.typeclass`
+   typeclasses, `laws.eo` EO-specific). Scaladoc states the equality and why
+   it holds.
+2. Ruleset wiring → the sibling `.discipline` `*Tests` class. Every existing
+   `checkAll` site inherits it with zero test-file changes — the stage-3
+   payoff.
+3. `sbt test` — a newly-failing registered instance halts everything: either
+   the law is wrong or the instance is unlawful; back to the user.
+4. `sbt mimaReportBinaryIssues`.
+5. Re-run mutation for affected modules — promotion kills are measured like
+   any candidate.
+6. Now-redundant tests-only properties are deleted (a stage-2→3 promotion is
+   also a consolidation); surface the new law in the site docs laws listing.

--- a/.claude/skills/improve-test-leverage/phases/plan.md
+++ b/.claude/skills/improve-test-leverage/phases/plan.md
@@ -1,0 +1,34 @@
+# Phase 3 — Plan + adversarial self-review (model: sonnet)
+
+Design the minimal artifact set from the triage pool, then attack the plan
+before anyone else can.
+
+## The plan table — one row per artifact, not per assertion
+
+```
+| # | Artifact | Tier/stage | File | Mutants killed (file:line:col) | Why no higher rung |
+```
+
+For each row include: generators with their **distribution argument** ("sizes
+biased to {0, 1, 15, 16, 17, 48}" — default `Gen.listOf` almost never crosses
+capacity thresholds), the invariant or law statement, and the causal chain
+per claimed kill (mutant flips X → assertion Y fails on input class Z).
+
+## Self-review checklist (each row must survive all five)
+
+1. Any tier-4/5 row that restates an existing law → replace with a tier-1
+   registration of that law.
+2. Any row whose generator can't actually reach the mutated branch — the
+   most common measured failure (thresholds, capacity boundaries).
+3. Negative fixtures must be *minimally* unlawful — break exactly the clause
+   the mutant weakens, keep all else lawful, or the fixture can't
+   distinguish weakened from original.
+4. Each claimed kill names the assertion that fails under the mutant.
+5. **The reduction question (new — the one early runs skipped): does this
+   artifact make any EXISTING test redundant?** If a new property subsumes
+   examples, the plan row lists the examples to delete and phase 6 deletes
+   them. Adding without subsuming is the exception, not the rule.
+
+In guided mode, present the plan to the user after self-review (this is the
+phase 3→4 gate). In loop mode, the pool + budget were confirmed once
+up-front; proceed.

--- a/.claude/skills/improve-test-leverage/phases/report.md
+++ b/.claude/skills/improve-test-leverage/phases/report.md
@@ -1,0 +1,48 @@
+# Phase 8 — Report (model: haiku)
+
+Close the run: refresh the QA page and present the trajectory with all three
+objective terms.
+
+## Refresh sequence (ORDER IS LOAD-BEARING)
+
+1. `SBT_OPTS="-Xmx6g" sbt coverageAll` — FIRST: its `clean` deletes every
+   stryker4s-report directory.
+2. Re-run mutation for the modules the run touched (commands in
+   phases/reports.md).
+3. `python3 site/tools/gen-qa-report.py` — regenerates the QA page tables;
+   `--check` must then pass (idempotency).
+4. Coverage truth = the aggregate XML's `<statement>` elements only. Neither
+   per-module log lines nor the sbt summary line are the aggregate.
+
+## The report
+
+Present the trajectory, not just the endpoint:
+
+```
+| Iter | Candidate | Pred | Meas | Body lines | Lines/kill | Verdict |
+|------|-----------|-----:|-----:|-----------:|-----------:|---------|
+| ...one row per iteration, accepted AND reverted...
+
+| Suite metric            | Before | After |
+|-------------------------|-------:|------:|
+| detected mutants        |        |       |
+| suite_test_count        |        |       |   <- net delta ≤ 0 or justified
+| suite test code lines   |        |       |
+| suite_kill_density      |        |       |   <- must have risen
+| branch coverage         |        |       |
+
+Promotions this run: <N examples folded into M properties; K properties
+registered as rulesets; law candidates surfaced: L (gated: promoted/kept/
+rejected/pending)>
+```
+
+Plus: classify-outs with justifications, `do_not_retry` additions with
+measured outcomes, and salvage notes for reverted artifacts a human might
+still want.
+
+If `suite_test_count` grew, the report MUST carry the justification (e.g.
+"pool was NoCoverage-dominated: new reach requires new artifacts; phase 6
+folded 9 pre-existing examples to compensate"). "We didn't get to it" is not
+a justification — phase 6 is mandatory.
+
+The QA page diff ships with the PR so the docs stay truthful.

--- a/.claude/skills/improve-test-leverage/phases/reports.md
+++ b/.claude/skills/improve-test-leverage/phases/reports.md
@@ -1,0 +1,66 @@
+# Phase 1 — Reports (model: haiku)
+
+Mechanical phase: produce or locate fresh scoverage + stryker4s reports and
+extract the baseline numbers into state.
+
+## Reuse before regenerating
+
+Reports are expensive (~15–25 min full sweep). Reuse if same branch and no
+main-source changes since they were written:
+
+- Coverage aggregate: `target/scala-*/scoverage-report/scoverage.xml`
+- Mutation per module: `<module>/target/stryker4s-report/<timestamp>/report.json`
+  (schema v2: `files{}.mutants[].status` ∈ Killed / Timeout / Survived /
+  NoCoverage / CompileError / Ignored)
+
+## Regenerating
+
+```sh
+SBT_OPTS="-Xmx6g -Xss8m" sbt coverageAll     # FIRST — its `clean` deletes stryker reports
+SBT_OPTS="-Xmx6g -Xss8m" sbt mutationAll     # SECOND — stops at avro's known failure (expected)
+```
+
+Order is load-bearing: `coverageAll` begins with `clean`, which deletes every
+`stryker4s-report` directory. Coverage first, always.
+
+**Single-module re-run** (used by phase 5 per candidate):
+
+```sh
+# schemes / circe — module-local suites:
+SBT_OPTS="-Xmx6g -Xss8m" sbt -batch 'set ThisBuild/tlFatalWarnings := false' \
+  'project schemes' stryker
+
+# core or laws — MUST include the borrow sets or every mutant is NoCoverage:
+SBT_OPTS="-Xmx6g -Xss8m" sbt -batch 'set ThisBuild/tlFatalWarnings := false' \
+  'set LocalProject("core")/Test/definedTests ++= (LocalProject("tests")/Test/definedTests).value' \
+  'set LocalProject("core")/Test/fullClasspath ++= (LocalProject("tests")/Test/fullClasspath).value' \
+  'project core' stryker
+```
+
+Never `<module>/stryker` (module-scoped task form) — it resolves test
+frameworks from the root project and reports 100% NoCoverage. Always
+`project <m>; stryker`.
+
+## Baseline into state
+
+Write to `target/test-leverage/state.json`:
+
+- per-module mutant status counts (keyed by module);
+- coverage: statement and branch counts **from the aggregate XML's
+  `<statement>` elements** — per-module log lines and even the sbt summary
+  line can show a single module, not the aggregate;
+- `suite_test_count`: number of specs2 examples + properties across all
+  `*/src/test/**/*.scala` (count `>>` example registrations);
+- `suite_test_loc`: scalafmt-normalized code lines of those files (the
+  comment/blank-excluding count from phases/eval.md).
+
+## Module caveats (do not fight these)
+
+| Module | Status | Why |
+|---|---|---|
+| `core`, `laws` | scored via borrowed `tests/` suite | task-level borrowing; see build.sbt `mutationAll` comment |
+| `generics` | structurally unscoreable (0%) | macro code expands at compile time — no runtime mutants; guarded by `generics/test` law specs |
+| `avro` | not scored | stryker's forked test-runner fails to initialise in its sandbox (specs pass under plain `sbt test`) |
+| `jsoniter` | not scored | instrumenting `PathParser.parseField` overflows the JVM 64 KB method limit (StringLiteral exclusion does NOT rescue it — tested) |
+| all | StringLiteral mutants excluded build-wide | error messages / labels / rule-set names — unkillable noise (`ThisBuild / strykerExcludedMutations`) |
+| all | CompileError mutants are normal | `-Yexplicit-nulls` flow-typing rejects some null-check mutations; excluded from the score — do NOT strip the flag |

--- a/.claude/skills/improve-test-leverage/phases/triage.md
+++ b/.claude/skills/improve-test-leverage/phases/triage.md
@@ -1,0 +1,44 @@
+# Phase 2 — Triage (model: sonnet)
+
+Sort every Survived / NoCoverage mutant into the leverage tiers and decide
+placement. For each mutant the question is not "what test kills this?" but
+"what is the most algebraic artifact that kills this *and its neighbors*?" —
+i.e. the highest reachable rung of the promotion ladder.
+
+For each mutant collect: mutator type, file:line:column, original vs
+replacement, and enough surrounding source to judge what behaviour changed.
+Read the source — measured misses in past runs came from guessing which
+conditional a line number referred to.
+
+| Tier | Artifact | Ladder stage | Kill profile | When |
+|---|---|---|---|---|
+| 0 | **Law promotion** (user gate — phases/law-scan.md) | 3 | one law × EVERY checkAll site repo-wide + clients | candidate property is universal for an abstraction |
+| 1 | **Ruleset registration** — `checkAll` via `CheckAllHelpers` against an uncovered instance/carrier/arity | 2 | one line ≈ 5–15 properties | the mutant sits on a path existing laws exercise, just not for this instance shape |
+| 2 | **Composed-optic law registration** — laws on `outer.andThen(inner)` for an uncovered family pair | 2 | kills in BOTH families + compose machinery | mutant in compose/carrier dispatch, reachable only through composition |
+| 3 | **Negative fixture** — minimally unlawful instance asserted to FAIL a specific law | — | the ONLY killer of law-WEAKENING mutants (guard→false, &&→ǀǀ) in `laws/` | every lawful instance satisfies the weakened law too |
+| 4 | **Property** (`forAll`) | 1 | one property ≈ N examples | machinery laws don't reach; generators must STRADDLE thresholds (capacity 16, OnStackLimit, transformRecursionLimit 512) or the mutated branch never executes |
+| 5 | **Example** | 0 | one kill each — the floor | fixed constants, single semantically-distinct inputs, dead contract corners |
+
+Every tier-5 plan entry must carry a one-line answer to "why is no higher
+rung reachable?" — tier 5 is permitted, defaulting to it is not.
+
+## Also mark
+
+- **Equivalent mutants** (with the reason a reviewer can check): early/extra
+  grow = alloc-only; copy-vs-share fast paths; `i >= n` → `i == n` when the
+  index increments by 1; routing conditionals between semantically identical
+  paths; hashCode mutants applied symmetrically to both comparands.
+- **Wrong-module reach**: a core mutant whose only natural exercise is a
+  schemes/circe path may be left to aggregate scoverage — note it rather
+  than forcing an artificial test.
+- **Replaced-soon code**: survivors in code an open PR rewrites (check the
+  branch list) — park, don't invest.
+
+## Placement rule
+
+- Mutant in `core` or `laws` → artifact lives in `tests/` (borrowed into
+  both mutation runs; one artifact scores twice).
+- Mutant in `schemes` / `circe` / `jsoniter` → that module's own `src/test`
+  (its stryker run sees nothing else).
+- Never duplicate an exercise across placements; choose the larger blast
+  radius.

--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -1,23 +1,18 @@
 ---
 name: test-fix
-description: Alias for improve-test-leverage biased to killing the currently-surviving mutants and covering uncovered branches — the gap-closing mode. Use when the QA page shows survivors or NoCoverage clusters that should be dead.
+description: Alias for improve-test-leverage biased to killing currently-surviving mutants and covering uncovered branches — the gap-closing mode. Use when the QA page shows survivors or NoCoverage clusters that should be dead.
 model: sonnet
 ---
 
 # test-fix — alias
 
-This is an alias for the `improve-test-leverage` skill. Read and follow
-`.claude/skills/improve-test-leverage/SKILL.md` in full, with this mode
-bias pre-set:
+Alias for `improve-test-leverage`. Run phases 1-5 of
+`.claude/skills/improve-test-leverage/` with this bias: candidates ranked by
+**measured gaps** (Survived / NoCoverage mutants, uncovered branches from the
+current reports), any ladder stage; every candidate must name the existing
+surviving mutants it kills. CLASSIFY-OUT is in scope — documenting an
+equivalent mutant IS a fix.
 
-- **Target selection**: rank candidates by *measured gaps* — Survived
-  and NoCoverage mutants and uncovered branches from the current
-  reports — rather than by abstract tier ambition. Any tier is fair
-  game, but every candidate must name the existing surviving mutants it
-  kills; do not add artifacts that only deepen already-killed paths.
-- CLASSIFY-OUT is in scope: a gap that turns out to be an equivalent
-  mutant or wrong-module reach is *fixed* by documenting it.
-- Arguments after `/test-fix` are passed through unchanged.
+Arguments pass through.
 
-Announce as: "Using improve-test-leverage (test-fix alias) — closing
-measured survivor/coverage gaps."
+Announce as: "Using improve-test-leverage (test-fix alias)."

--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: test-fix
+description: Alias for improve-test-leverage biased to killing the currently-surviving mutants and covering uncovered branches — the gap-closing mode. Use when the QA page shows survivors or NoCoverage clusters that should be dead.
+model: sonnet
+---
+
+# test-fix — alias
+
+This is an alias for the `improve-test-leverage` skill. Read and follow
+`.claude/skills/improve-test-leverage/SKILL.md` in full, with this mode
+bias pre-set:
+
+- **Target selection**: rank candidates by *measured gaps* — Survived
+  and NoCoverage mutants and uncovered branches from the current
+  reports — rather than by abstract tier ambition. Any tier is fair
+  game, but every candidate must name the existing surviving mutants it
+  kills; do not add artifacts that only deepen already-killed paths.
+- CLASSIFY-OUT is in scope: a gap that turns out to be an equivalent
+  mutant or wrong-module reach is *fixed* by documenting it.
+- Arguments after `/test-fix` are passed through unchanged.
+
+Announce as: "Using improve-test-leverage (test-fix alias) — closing
+measured survivor/coverage gaps."

--- a/.claude/skills/test-prune/SKILL.md
+++ b/.claude/skills/test-prune/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: test-prune
+description: Alias for improve-test-leverage biased to CONSOLIDATE moves — shrink test LOC while holding every kill. Replaces example clusters with laws/properties, deletes tests that restate laws, merges redundant properties.
+model: sonnet
+---
+
+# test-prune — alias
+
+This is an alias for the `improve-test-leverage` skill. Read and follow
+`.claude/skills/improve-test-leverage/SKILL.md` in full, with this mode
+bias pre-set:
+
+- **Candidate moves**: CONSOLIDATE only (step 9's rules — no test may
+  restate what a law already says; >1 example on one code path becomes
+  one property; merge same-operation properties). The accept criterion
+  is the consolidation one: `net_test_lines_added < 0` with **zero kill
+  regression**, measured by re-running the affected mutation targets —
+  never assumed.
+- No new artifacts; no CLASSIFY-OUT.
+- Arguments after `/test-prune` are passed through unchanged.
+
+Announce as: "Using improve-test-leverage (test-prune alias) — shrinking
+test LOC at held kill capacity."

--- a/.claude/skills/test-prune/SKILL.md
+++ b/.claude/skills/test-prune/SKILL.md
@@ -1,23 +1,22 @@
 ---
 name: test-prune
-description: Alias for improve-test-leverage biased to CONSOLIDATE moves — shrink test LOC while holding every kill. Replaces example clusters with laws/properties, deletes tests that restate laws, merges redundant properties.
-model: sonnet
+description: Alias for improve-test-leverage running ONLY the consolidation pipeline — shrink test count and LOC while holding every kill. Replaces example clusters with properties, deletes tests that restate laws, merges redundant properties.
+model: opus
 ---
 
 # test-prune — alias
 
-This is an alias for the `improve-test-leverage` skill. Read and follow
-`.claude/skills/improve-test-leverage/SKILL.md` in full, with this mode
-bias pre-set:
+Alias for `improve-test-leverage`. Run phases 1, 6 and 8 of
+`.claude/skills/improve-test-leverage/` (reports → **consolidate** → report):
+pure reduction. The whole point is phase 6
+(`phases/consolidate.md`) — N examples to one property, properties to
+ruleset registrations, deletion of law-restating tests — with its
+zero-kill-regression eval. Acceptance: `net_test_lines_added < 0` and
+`suite_test_count` strictly reduced, kills held (measured, not assumed).
+Law candidates that surface during folding are queued for phase 7's user
+gate.
 
-- **Candidate moves**: CONSOLIDATE only (step 9's rules — no test may
-  restate what a law already says; >1 example on one code path becomes
-  one property; merge same-operation properties). The accept criterion
-  is the consolidation one: `net_test_lines_added < 0` with **zero kill
-  regression**, measured by re-running the affected mutation targets —
-  never assumed.
-- No new artifacts; no CLASSIFY-OUT.
-- Arguments after `/test-prune` are passed through unchanged.
+Arguments pass through (module focus narrows the inventory).
 
-Announce as: "Using improve-test-leverage (test-prune alias) — shrinking
-test LOC at held kill capacity."
+Announce as: "Using improve-test-leverage (test-prune alias) — pure
+reduction."

--- a/.claude/skills/test-upgrade/SKILL.md
+++ b/.claude/skills/test-upgrade/SKILL.md
@@ -1,21 +1,18 @@
 ---
 name: test-upgrade
-description: Alias for improve-test-leverage biased to ADD moves that upgrade the suite's algebraic tier — law promotions, ruleset registrations, composed-optic laws, properties replacing examples. Use to raise mutant-kill capacity per test line.
+description: Alias for improve-test-leverage biased to ADD moves that raise the suite's promotion-ladder stage — ruleset registrations, composed-optic laws, negative fixtures, properties replacing examples. Use to raise mutant-kill capacity per test line.
 model: sonnet
 ---
 
 # test-upgrade — alias
 
-This is an alias for the `improve-test-leverage` skill. Read and follow
-`.claude/skills/improve-test-leverage/SKILL.md` in full, with this mode
-bias pre-set:
+Alias for `improve-test-leverage`. Run phases 1-5 of
+`.claude/skills/improve-test-leverage/` (reports → triage → plan → execute →
+eval) with this bias: **ADD moves only, highest ladder stage first**; no
+CONSOLIDATE planning (that is /test-prune's job); CLASSIFY-OUT allowed.
+Plan rows must still answer phase 3's reduction question — subsumed examples
+are listed for deletion even in upgrade mode.
 
-- **Candidate moves**: ADD only, preferring the highest available tier
-  (law promotion → ruleset registration → composed-optic laws → negative
-  fixtures → properties). Do not plan CONSOLIDATE moves; CLASSIFY-OUT is
-  allowed when triage demands it.
-- Arguments after `/test-upgrade` are passed through unchanged (e.g.
-  `loop 3`, a module focus).
+Arguments pass through (e.g. `loop 3`, a module focus).
 
-Announce as: "Using improve-test-leverage (test-upgrade alias) — adding
-higher-tier artifacts."
+Announce as: "Using improve-test-leverage (test-upgrade alias)."

--- a/.claude/skills/test-upgrade/SKILL.md
+++ b/.claude/skills/test-upgrade/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: test-upgrade
+description: Alias for improve-test-leverage biased to ADD moves that upgrade the suite's algebraic tier — law promotions, ruleset registrations, composed-optic laws, properties replacing examples. Use to raise mutant-kill capacity per test line.
+model: sonnet
+---
+
+# test-upgrade — alias
+
+This is an alias for the `improve-test-leverage` skill. Read and follow
+`.claude/skills/improve-test-leverage/SKILL.md` in full, with this mode
+bias pre-set:
+
+- **Candidate moves**: ADD only, preferring the highest available tier
+  (law promotion → ruleset registration → composed-optic laws → negative
+  fixtures → properties). Do not plan CONSOLIDATE moves; CLASSIFY-OUT is
+  allowed when triage demands it.
+- Arguments after `/test-upgrade` are passed through unchanged (e.g.
+  `loop 3`, a module focus).
+
+Announce as: "Using improve-test-leverage (test-upgrade alias) — adding
+higher-tier artifacts."

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,142 @@
+# Quality report: cross-module coverage (scoverage) + mutation testing
+# (stryker4s), with the site/docs/quality-assurance.md tables regenerated from
+# the live reports.
+#
+# Deliberately hand-written and OUTSIDE the sbt-github-actions-generated
+# `ci.yml` (which must not be edited by hand). This is heavy — a full
+# instrumented test sweep plus per-mutant test runs across every runtime-logic
+# module — so it never runs on the push / PR critical path. It fires on release
+# tags (`v*`) so each release ships a fresh quality snapshot, and on demand via
+# `workflow_dispatch`.
+#
+# Outputs are uploaded as artifacts (HTML reports + the regenerated markdown);
+# committing the markdown back to the page is intentionally left to a human
+# (bot-commits-on-a-tag are awkward) — download the artifact and commit it, or
+# run `sbt coverageAll mutationAll && python3 site/tools/gen-qa-report.py`
+# locally before tagging.
+name: Quality
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Coverage + mutation
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    env:
+      # Generous heap: the `set tlFatalWarnings := false` reapply baked into the
+      # aliases re-evaluates the Laika docs settings, which OOMs on a small heap.
+      SBT_OPTS: "-Xmx6g -Xss8m -Dsbt.color=false"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Setup Java (temurin@21)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: Coverage (scoverage aggregate)
+        run: sbt -batch coverageAll
+
+      - name: Mutation testing (stryker4s)
+        # Per-module via `project <m>; stryker` (see build.sbt / plugins.sbt).
+        # Run each module in its own sbt invocation rather than the `mutationAll`
+        # alias: a module whose stryker run fails (e.g. a sandbox setup error)
+        # must NOT abort the remaining modules or the regenerate step. A low
+        # score never fails the build either (strykerThresholdsBreak = 0) — this
+        # step is the report, not a gate, so it always succeeds.
+        run: |
+          # core and laws borrow the `tests` module's compiled suite (task-level,
+          # no project cycle) so their mutants are scored by the behavioural
+          # suite that actually guards them — see the mutationAll alias in
+          # build.sbt. StringLiteral mutants are excluded for every module via
+          # ThisBuild/strykerExcludedMutations (error-message / label noise).
+          echo "::group::stryker core (with borrowed tests/ suite)"
+          sbt -batch "set ThisBuild/tlFatalWarnings := false" \
+            'set LocalProject("core")/Test/definedTests ++= (LocalProject("tests")/Test/definedTests).value' \
+            'set LocalProject("core")/Test/fullClasspath ++= (LocalProject("tests")/Test/fullClasspath).value' \
+            "project core" stryker \
+            || echo "::warning title=stryker::mutation run failed for core (see log / quality-assurance.md notes)"
+          echo "::endgroup::"
+          echo "::group::stryker laws (with borrowed tests/ suite)"
+          sbt -batch "set ThisBuild/tlFatalWarnings := false" \
+            'set LocalProject("laws")/Test/definedTests ++= (LocalProject("tests")/Test/definedTests).value' \
+            'set LocalProject("laws")/Test/fullClasspath ++= (LocalProject("tests")/Test/fullClasspath).value' \
+            "project laws" stryker \
+            || echo "::warning title=stryker::mutation run failed for laws (see log / quality-assurance.md notes)"
+          echo "::endgroup::"
+          for p in generics schemes circeIntegration avroIntegration jsoniterIntegration; do
+            echo "::group::stryker $p"
+            sbt -batch "set ThisBuild/tlFatalWarnings := false" "project $p" stryker \
+              || echo "::warning title=stryker::mutation run failed for $p (see log / quality-assurance.md notes)"
+            echo "::endgroup::"
+          done
+
+      - name: Regenerate quality-assurance.md tables
+        run: python3 site/tools/gen-qa-report.py
+
+      - name: Render summary
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import os, pathlib, re
+          page = pathlib.Path("site/docs/quality-assurance.md")
+          out = os.environ["GITHUB_STEP_SUMMARY"]
+          with open(out, "a") as f:
+              f.write("# Quality report\n\n")
+              if not page.exists():
+                  f.write("quality-assurance.md not found.\n")
+                  raise SystemExit(0)
+              txt = page.read_text(encoding="utf-8")
+              for marker, title in [("coverage", "Coverage"), ("mutation", "Mutation testing")]:
+                  m = re.search(
+                      rf"<!-- BEGIN GENERATED: {marker} -->(.*?)<!-- END GENERATED: {marker} -->",
+                      txt, re.DOTALL,
+                  )
+                  f.write(f"## {title}\n\n{m.group(1).strip() if m else '(not generated)'}\n\n")
+          PY
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: scoverage-report
+          path: "**/scoverage-report/**"
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload mutation reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: stryker4s-reports
+          path: "**/stryker4s-report/**"
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload regenerated QA page
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: quality-assurance-md
+          path: site/docs/quality-assurance.md
+          retention-days: 30
+          if-no-files-found: warn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,35 +94,92 @@ git push   --no-verify                # bypass pre-push if you need to
 coverage:
 
 ```sh
-sbt "clean; coverage; core/test; tests/test; circeIntegration/test; schemes/test; coverageReport; coverageAggregate"
+SBT_OPTS="-Xmx6g" sbt coverageAll
+# alias for: set ThisBuild/tlFatalWarnings := false; clean; coverage;
+#            test; coverageReport; coverageAggregate
 # HTML + XML under <module>/target/scala-<ver>/scoverage-report/
 # Aggregate report at target/scala-<ver>/scoverage-report/
 ```
 
-The `circeIntegration/test` and `schemes/test` calls are load-bearing —
-without them, `circe/*.scala` and `schemes/*.scala` (and the schemes-only
-exercise of core's `Optic.cross`) are silently omitted from the scoverage
-report. `coverageAggregate` rolls the per-module reports into a single
-cross-module view at the repo root.
+`coverageAll` runs the whole root-aggregate `test`, so every module's
+suite is exercised and `coverageAggregate` rolls them into one
+cross-module per-package view at the repo root. It relaxes the always-on
+`-Werror` (`tlFatalWarnings`) first because scoverage-instrumented
+sources can surface `-Wunused` warnings, and wants a larger heap because
+the `set` reapply re-evaluates the Laika docs settings.
 
 The report directory sits under `target/` and is `.gitignore`d.
 
-Coverage is the project's primary quality signal. The law and behaviour
-suites in `cats-eo-tests` currently reach ~70 %% of core's statements and
-branches — the rest is either pure type-level machinery (no runtime
-footprint) or code reachable only when someone adds the matching carrier
-/ composer instances to core.
+Coverage is the project's primary quality signal — see the
+[Quality Assurance docs page](./site/docs/quality-assurance.md) for the
+live per-package numbers (statement %, branch %, BC/SC ratio). The rest
+is either pure type-level machinery (no runtime footprint) or code
+reachable only when someone adds the matching carrier / composer
+instances.
 
-**Why not mutation testing?** sbt-stryker4s was evaluated earlier and
-dropped. Because EO is mostly type-level, stryker4s' default mutators
-find exactly **one** mutable runtime expression across the whole
-codebase — not enough signal to justify the plugin, the per-checkout
-`target/stryker4s-report/` directories, or the CI time. *Future work:*
-teaching stryker about EO-specific mutators (e.g. swapping the `to` /
-`from` halves of an `Optic` constructor, or flipping associators in
-`AssociativeFunctor` instances) would make mutation testing a much
-richer signal than the default AST-level mutations. A good project for
-someone who wants to understand stryker's mutator plugin API.
+### Mutation testing (stryker4s)
+
+[`sbt-stryker4s`](https://stryker-mutator.io/docs/stryker4s/) lives in
+[`project/plugins.sbt`](./project/plugins.sbt). It was dropped in an
+earlier pass (a whole-project run found a single mutable runtime
+expression — EO was almost entirely type-level) and reintroduced once
+`schemes` grew real runtime machinery and core gained opaque-carrier
+dispatch.
+
+```sh
+SBT_OPTS="-Xmx6g" sbt mutationAll
+# per-module reports under <module>/target/stryker4s-report/<ts>/
+```
+
+Key facts, all the hard-won kind:
+
+- **Invoke as `project <m>; stryker`, NOT `<m>/stryker`.** The
+  module-scoped task form reads `loadedTestFrameworks` from the
+  aggregating root project (no test deps), so specs2 is invisible and
+  *every* mutant comes back `NoCoverage`. The `mutationAll` alias uses the
+  project-switch form across core, laws, generics, schemes, circe, avro,
+  jsoniter.
+- **It's a report, not a gate** (`strykerThresholdsBreak := 0`): a low
+  score never fails the build.
+- **`core` and `laws` are scored against the `tests/` suite via
+  task-level borrowing.** `core.dependsOn(tests % Test)` would be a
+  project cycle (tests → laws/generics → core), but cross-project *task*
+  references are legal: `mutationAll` appends `tests/Test/definedTests` +
+  `tests/Test/fullClasspath` to each module's Test scope for the run.
+  Sound because stryker compiles mutants behind runtime switches
+  (binary-compatible), so tests' specs — compiled against the unmutated
+  modules — still exercise the mutated bytecode (verified: core 3% →
+  ~63%/78% covered; laws unscoreable → ~97%). Works even though laws has
+  NO test framework of its own — specs2 is detected from the borrowed
+  classpath. Deliberately scoped to the alias: a permanent setting would
+  make root `sbt test` run the suite twice.
+- **StringLiteral mutants are excluded build-wide**
+  (`ThisBuild / strykerExcludedMutations`): string literals here are
+  error messages, vestigial-arm labels, and discipline rule-set names —
+  nothing any suite asserts on, so they survive as pure noise (laws: 99
+  of 101 unfiltered survivors were name labels).
+- **Mutating `laws` is the "who tests the tests" probe.** Killed mutant =
+  the discipline suites notice a corrupted law definition. The surviving
+  mutants are law-WEAKENING mutations (guard → `false` in
+  `AffineFoldLaws.missIsEmpty`, `&&` → `||` in
+  `ModifyFLaws.functorIdentity`/`functorComposition`): all instances
+  under test satisfy the weakened law too, so only **negative fixtures**
+  (deliberately unlawful instances pinned to fail) would kill them — a
+  known follow-up.
+  **`generics`** is macro code (expands at compile time → no runtime
+  mutants to cover), so it structurally can't be scored. Caveats are
+  documented in the QA page. The high-signal modules are `core`, `laws`,
+  `schemes`, `circe`.
+
+The [`quality.yml`](./.github/workflows/quality.yml) workflow runs
+`coverageAll` + `mutationAll` + `site/tools/gen-qa-report.py` on every
+release tag, refreshing the QA page tables and uploading the HTML reports
+as artifacts. The `improve-test-leverage` skill
+(`.claude/skills/improve-test-leverage/SKILL.md`) consumes both reports
+to plan high-leverage test additions. *Future work:* EO-specific mutators
+(swapping the `to` / `from` halves of an `Optic`, flipping
+`AssociativeFunctor` associators) would beat the default AST-level
+mutations — a good entry into stryker's mutator plugin API.
 
 ### Benchmarks (JMH vs Monocle)
 

--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,37 @@ ThisBuild / unusedCodeConfig ~= { c =>
 }
 
 // -------------------------------------------------------------------
+// Mutation testing (sbt-stryker4s). The plugin auto-derives the Scala
+// dialect from `scalaVersion` (3.x → scalameta `Scala3`) and resolves
+// each sub-project's base-dir / mutate globs from its own `Compile`
+// sources, so `project <m>; stryker` mutates that module and runs its
+// OWN `Test / test` — no per-module config files needed. We only pin
+// the cross-cutting knobs here on ThisBuild (the plugin leaves these
+// unset by default, so ThisBuild values are inherited by every module):
+//
+//   - reporters: console for the live log, html + json for the report
+//     artifacts the release workflow uploads and gen-qa-report.py reads.
+//   - thresholds/break = 0: stryker is a REPORT, never a CI gate. A low
+//     mutation score must not fail the build (most of cats-eo is
+//     type-level; see site/docs/quality-assurance.md for why).
+//   - StringLiteral mutants excluded everywhere: in this codebase string
+//     literals are error messages, vestigial-arm labels, and discipline
+//     rule-set names — nothing a suite asserts on, so they survive as
+//     pure noise (laws: 99 of 101 unfiltered survivors were name labels).
+//     The trade-off (losing kills on semantically-meaningful strings) is
+//     acceptable here because behaviour-bearing strings don't exist on
+//     the main-source hot paths.
+//
+// Run with fatal warnings relaxed (`set ThisBuild/tlFatalWarnings :=
+// false`) since instrumented/mutated sources can trip `-Wunused` under
+// the always-on `-Werror` above. The `mutationAll` alias and the
+// `quality.yml` release workflow both do this.
+// -------------------------------------------------------------------
+ThisBuild / strykerReporters := Seq("console", "html", "json")
+ThisBuild / strykerThresholdsBreak := 0
+ThisBuild / strykerExcludedMutations := Seq("StringLiteral")
+
+// -------------------------------------------------------------------
 // Bump hardcoded GitHub Action versions that sbt-typelevel 0.8.5
 // pins to older releases:
 //
@@ -703,3 +734,64 @@ lazy val benchmarks: Project = project
 // DRY'd). Append a filter: `sbt "bench .*OrderAvroBench.*"`.
 addCommandAlias("bench", "benchmarks/Jmh/run -i 5 -wi 3 -f 3 -t 1")
 addCommandAlias("benchQuick", "benchmarks/Jmh/run -i 3 -wi 2 -f 1 -t 1")
+
+// -------------------------------------------------------------------
+// Quality-assurance sweeps (scoverage + stryker4s). Both feed the
+// numbers on site/docs/quality-assurance.md via site/tools/gen-qa-report.py
+// and run at release time in .github/workflows/quality.yml. Both relax
+// the always-on `-Werror` (tlFatalWarnings) first: scoverage- and
+// stryker-instrumented sources can surface `-Wunused` warnings that
+// would otherwise abort the run. Give sbt a generous heap when running
+// these — `SBT_OPTS="-Xmx6g" sbt coverageAll` — the `set` reapply
+// re-evaluates the Laika docs settings, which OOMs on a small heap.
+// -------------------------------------------------------------------
+
+// Full cross-module statement/branch coverage. Root `test` exercises
+// every aggregated module's suite, so `coverageAggregate` rolls up a
+// complete per-package view.
+addCommandAlias(
+  "coverageAll",
+  "set ThisBuild/tlFatalWarnings := false; clean; coverage; test; coverageReport; coverageAggregate",
+)
+
+// Mutation testing across the published modules (tests/benchmarks/docs
+// aren't published). Uses the `project <m>; stryker` form, NOT
+// `<m>/stryker`: see the plugins.sbt note — the module-scoped task reads
+// `loadedTestFrameworks` from the empty root project and marks every
+// mutant NoCoverage.
+//
+// The `set` lines borrow the `tests` module's compiled suite into core's
+// and laws' Test scopes so their mutants get killed by the behavioural
+// suite that actually guards them (core alone has 3 smoke specs → a
+// dishonest 3% score, borrowed ~63%/74% covered; laws has no in-module
+// suite at all, borrowed ~97%). This is TASK-level borrowing:
+// `core.dependsOn(tests % Test)` would be a project cycle (tests →
+// laws/generics → core), but cross-project task references are legal. It
+// works because stryker compiles all mutants into the sandbox classes
+// behind runtime switches (binary-compatible), so tests' specs —
+// compiled against the unmutated modules — still exercise the mutated
+// bytecode at run time. Scoped to this alias on purpose: a permanent
+// setting would make root `sbt test` run the tests suite twice.
+//
+// Mutating laws is the "who tests the tests" probe: a killed mutant
+// means the discipline suites notice a corrupted law; a survivor
+// pinpoints a law whose discriminating power nothing exercises (the
+// known survivors are law-WEAKENING mutations — guard→false, &&→|| —
+// killable only by negative fixtures, i.e. deliberately unlawful
+// instances pinned to fail).
+addCommandAlias(
+  "mutationAll",
+  "set ThisBuild/tlFatalWarnings := false; " +
+    "set LocalProject(\"core\")/Test/definedTests ++= (LocalProject(\"tests\")/Test/definedTests).value; " +
+    "set LocalProject(\"core\")/Test/fullClasspath ++= (LocalProject(\"tests\")/Test/fullClasspath).value; " +
+    "set LocalProject(\"laws\")/Test/definedTests ++= (LocalProject(\"tests\")/Test/definedTests).value; " +
+    "set LocalProject(\"laws\")/Test/fullClasspath ++= (LocalProject(\"tests\")/Test/fullClasspath).value; " +
+    "project core; stryker; " +
+    "project laws; stryker; " +
+    "project generics; stryker; " +
+    "project schemes; stryker; " +
+    "project circeIntegration; stryker; " +
+    "project avroIntegration; stryker; " +
+    "project jsoniterIntegration; stryker; " +
+    "project root",
+)

--- a/circe/src/test/scala/dev/constructive/eo/circe/JsonIndexBoundsSpec.scala
+++ b/circe/src/test/scala/dev/constructive/eo/circe/JsonIndexBoundsSpec.scala
@@ -1,0 +1,32 @@
+package dev.constructive.eo.circe
+
+import scala.language.implicitConversions
+
+import cats.data.Ior
+import io.circe.syntax.*
+import org.specs2.mutable.Specification
+
+/** Index-bounds discrimination for the array walk: the existing specs exercise
+  * out-of-range-high on a 1-element array and index 0 on non-arrays, but never a SUCCESSFUL walk
+  * at indices 0 and >0 of one array, nor a negative index — so operator mutants on the
+  * `idx < 0 || idx >= arr.length` check survived.
+  */
+class JsonIndexBoundsSpec extends Specification:
+
+  import JsonSpecFixtures.*
+
+  // covers: JsonWalk.walkStep Index bounds (JsonWalk.scala:62), every operator variant —
+  // `idx < 0` weakened to `> 0` breaks at(1), to `<= 0` breaks at(0); a weakened
+  // `idx >= length` lets at(3)/at(-1) walk off the array.
+  "indices 0 and 1 read their elements; -1 and length fail IndexOutOfRange" >> {
+    val basket = Basket("Alice", Vector(Order("A"), Order("B"), Order("C"))).asJson
+    def run(i: Int) = codecPrism[Basket].items.at(i).modify(identity)(basket)
+    val valid = (run(0), run(1)) match
+      case (Ior.Right(_), Ior.Right(_)) => true
+      case _                            => false
+    def oob(i: Int) = run(i) match
+      case Ior.Both(chain, _) =>
+        chain.headOption.get == JsonFailure.IndexOutOfRange(PathStep.Index(i), 3)
+      case _ => false
+    (valid, oob(-1), oob(3)) must beEqualTo((true, true, true))
+  }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,22 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 
+// `sbt-stryker4s` drives mutation testing. Mutation testing was
+// previously evaluated and dropped because cats-eo was almost entirely
+// type-level (a whole-project run found a single mutable runtime
+// expression). The `schemes` module's runtime machinery and core's
+// opaque-carrier dispatch changed that, so it's back — run on demand /
+// at release rather than as a per-PR gate (see `mutationAll` in
+// build.sbt and site/docs/quality-assurance.md).
+// Stryker runs each module's OWN `Test / test` against that module's
+// mutants. NB: invoke it as `project <module>; stryker`, NOT
+// `<module>/stryker` — the module-scoped task form resolves
+// `loadedTestFrameworks` from the aggregating root project (which has no
+// test deps), so every mutant comes back NoCoverage; switching the
+// current project first makes specs2 visible. 0.20.x auto-derives the
+// Scala 3 dialect from scalaVersion.
+addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.20.3")
+
 // Format check gate for CI (`sbt scalafmtCheckAll scalafmtSbtCheck`
 // in the workflow). The project ships a `.scalafmt.conf` pinned to
 // 3.x; sbt-scalafmt honours that pin automatically.

--- a/site/docs/directory.conf
+++ b/site/docs/directory.conf
@@ -10,5 +10,6 @@ laika.navigationOrder = [
   extensibility.md
   cookbook.md
   benchmarks.md
+  quality-assurance.md
   migration-from-monocle.md
 ]

--- a/site/docs/quality-assurance.md
+++ b/site/docs/quality-assurance.md
@@ -73,7 +73,7 @@ its statement coverage looks healthy. Packages with no branch statements show
 | `dev.constructive.eo.avro` | 979/1430 | 68.5% | 214/355 | 60.3% | 0.88 |
 | `dev.constructive.eo.circe` | 665/846 | 78.6% | 128/174 | 73.6% | 0.94 |
 | `dev.constructive.eo.compose` | 90/118 | 76.3% | 7/8 | 87.5% | 1.15 |
-| `dev.constructive.eo.data` | 951/1139 | 83.5% | 141/172 | 82.0% | 0.98 |
+| `dev.constructive.eo.data` | 998/1139 | 87.6% | 153/172 | 89.0% | 1.02 |
 | `dev.constructive.eo.forgetful` | 24/28 | 85.7% | — | — | — |
 | `dev.constructive.eo.generics` | 397/472 | 84.1% | 66/79 | 83.5% | 0.99 |
 | `dev.constructive.eo.jsoniter` | 436/583 | 74.8% | 109/170 | 64.1% | 0.86 |
@@ -149,15 +149,7 @@ The high-signal rows are therefore `core` and `laws` (via the borrowed suite),
 run time by the suite stryker runs.
 
 <!-- BEGIN GENERATED: mutation -->
-| Module | Killed | Timeout | Survived | No&nbsp;cov | Compile&nbsp;err | Score (total) | Score (covered) | Notes |
-|---|--:|--:|--:|--:|--:|--:|--:|---|
-| `core` | 153 | 2 | 28 | 17 | 3 | 77.5% | 84.7% | Scored against the cross-module suite in `tests/`, task-borrowed into core's Test scope by `mutationAll`. |
-| `laws` | 82 | 1 | 0 | 0 | 0 | 100.0% | 100.0% | Borrowed `tests/` suite; the negative fixtures in `UnlawfulFixturesSpec` keep the law-weakening mutants dead — see prose. |
-| `generics` | 0 | 0 | 0 | 58 | 0 | 0.0% | — | Macro code: it expands at compile time, so mutants leave no runtime footprint for the test run to cover. |
-| `schemes` | 58 | 0 | 18 | 0 | 5 | 76.3% | 76.3% |  |
-| `circe` | 33 | 1 | 5 | 15 | 0 | 63.0% | 87.2% |  |
-| `avro` | — | — | — | — | — | — | — | Not scored: stryker's forked test-runner fails to initialise in the sandbox (the specs pass under plain `sbt test`). |
-| `jsoniter` | — | — | — | — | — | — | — | Not scored: instrumenting `PathParser.parseField` blows the JVM 64 KB method-size limit — one giant byte-cursor method, un-mutatable in place. |
+> _No stryker4s reports found. Run `sbt mutationAll`, then re-run `site/tools/gen-qa-report.py`._
 <!-- END GENERATED: mutation -->
 
 ## Regenerating these numbers

--- a/site/docs/quality-assurance.md
+++ b/site/docs/quality-assurance.md
@@ -149,7 +149,15 @@ The high-signal rows are therefore `core` and `laws` (via the borrowed suite),
 run time by the suite stryker runs.
 
 <!-- BEGIN GENERATED: mutation -->
-> _No stryker4s reports found. Run `sbt mutationAll`, then re-run `site/tools/gen-qa-report.py`._
+| Module | Killed | Timeout | Survived | No&nbsp;cov | Compile&nbsp;err | Score (total) | Score (covered) | Notes |
+|---|--:|--:|--:|--:|--:|--:|--:|---|
+| `core` | 169 | 4 | 23 | 4 | 3 | 86.5% | 88.3% | Scored against the cross-module suite in `tests/`, task-borrowed into core's Test scope by `mutationAll`. |
+| `laws` | 83 | 0 | 0 | 0 | 0 | 100.0% | 100.0% | Borrowed `tests/` suite; the negative fixtures in `UnlawfulFixturesSpec` keep the law-weakening mutants dead — see prose. |
+| `generics` | 0 | 0 | 0 | 58 | 0 | 0.0% | — | Macro code: it expands at compile time, so mutants leave no runtime footprint for the test run to cover. |
+| `schemes` | 58 | 0 | 18 | 0 | 5 | 76.3% | 76.3% |  |
+| `circe` | 36 | 0 | 3 | 15 | 0 | 66.7% | 92.3% |  |
+| `avro` | — | — | — | — | — | — | — | Not scored: stryker's forked test-runner fails to initialise in the sandbox (the specs pass under plain `sbt test`). |
+| `jsoniter` | — | — | — | — | — | — | — | Not scored: instrumenting `PathParser.parseField` blows the JVM 64 KB method-size limit — one giant byte-cursor method, un-mutatable in place. |
 <!-- END GENERATED: mutation -->
 
 ## Regenerating these numbers

--- a/site/docs/quality-assurance.md
+++ b/site/docs/quality-assurance.md
@@ -1,0 +1,189 @@
+# Quality Assurance
+
+`cats-eo` is mostly a *type-level* library: a large part of its correctness is
+discharged by the compiler before any test runs. The quality signals it tracks
+reflect that, in roughly increasing cost-to-fool order:
+
+1. **Types as tests** — the [composition matrix](#composition-matrix) pins, at
+   compile time, exactly which optic families compose with which (and at what
+   strength), and which combinations are deliberately rejected. A regression
+   that loosened or broke the lattice fails to compile.
+2. **Discipline law suites** — `cats-eo-laws` defines the optic and typeclass
+   laws; `cats-eo-tests` and the integration modules run them against concrete
+   instances.
+3. **Statement / branch [coverage](#coverage)** (scoverage) — the project's
+   primary runtime-quality signal. See the
+   [`CLAUDE.md` coverage note](https://github.com/Constructive-Programming/eo/blob/main/CLAUDE.md)
+   for why ~70–80 % is the expected ceiling: the remainder is pure type-level
+   machinery with no runtime footprint, or code reachable only once a
+   downstream carrier instance is added.
+4. **[Mutation testing](#mutation-testing)** (stryker4s) — the strongest and
+   most expensive signal, and the one that historically did *not* pay its way
+   here. It was reintroduced once the `schemes` module grew real runtime
+   machinery (the `ArrayDeque` fold machine, the effectful M-drivers, `PSVec`)
+   and the opaque-carrier compose work added runtime dispatch to `core`.
+
+The numbers below are regenerated from the live reports by
+[`site/tools/gen-qa-report.py`](https://github.com/Constructive-Programming/eo/blob/main/site/tools/gen-qa-report.py);
+see [Regenerating these numbers](#regenerating-these-numbers).
+
+## Composition matrix
+
+Every `(outer family ∘ inner family)` pair either composes — *import-free and
+without a type ascription*, landing at the strength described in the
+[optic taxonomy](optics.md) — or it does **not** compile, because the cell is
+void by design (building through a non-invertible optic, writing through a
+read-only one, reading through a write-only one). The grid is the pass/fail
+projection of
+[`CompositionMatrixSpec`](https://github.com/Constructive-Programming/eo/blob/main/tests/src/test/scala/dev/constructive/eo/CompositionMatrixSpec.scala),
+which is the single source of truth — if a cell starts needing an import or an
+ascription, that spec goes red.
+
+<!-- BEGIN GENERATED: matrix -->
+| outer ∘ inner | iso | lens | prism | optional | trav | getter | affold | fold | modify | review | unfold |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| **iso** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **lens** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| **prism** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **optional** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| **trav** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| **getter** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| **affold** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| **fold** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| **modify** | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ |
+| **review** | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ |
+| **unfold** | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ |
+
+*✓ composes import-free at the strength shown in the [optic taxonomy](optics.md); ✗ does not compile (void by design — building through a read-only optic, reading through a write-only one, etc.). 87 composing / 34 void cells, pinned by `CompositionMatrixSpec`.*
+<!-- END GENERATED: matrix -->
+
+## Coverage
+
+Statement and branch coverage per package, from the cross-module scoverage
+**aggregate** (`sbt coverageAll`). `BC/SC` is the branch-coverage ÷
+statement-coverage ratio — a value well below 1 flags a package whose
+conditionals are under-exercised relative to its straight-line code, even when
+its statement coverage looks healthy. Packages with no branch statements show
+`—`.
+
+<!-- BEGIN GENERATED: coverage -->
+| Package | Statements | Stmt&nbsp;% | Branches | Branch&nbsp;% | BC/SC |
+|---|--:|--:|--:|--:|--:|
+| `dev.constructive.eo.accessor` | 8/8 | 100.0% | — | — | — |
+| `dev.constructive.eo.avro` | 979/1430 | 68.5% | 214/355 | 60.3% | 0.88 |
+| `dev.constructive.eo.circe` | 665/846 | 78.6% | 128/174 | 73.6% | 0.94 |
+| `dev.constructive.eo.compose` | 90/118 | 76.3% | 7/8 | 87.5% | 1.15 |
+| `dev.constructive.eo.data` | 951/1139 | 83.5% | 141/172 | 82.0% | 0.98 |
+| `dev.constructive.eo.forgetful` | 24/28 | 85.7% | — | — | — |
+| `dev.constructive.eo.generics` | 397/472 | 84.1% | 66/79 | 83.5% | 0.99 |
+| `dev.constructive.eo.jsoniter` | 436/583 | 74.8% | 109/170 | 64.1% | 0.86 |
+| `dev.constructive.eo.laws` | 151/151 | 100.0% | 6/6 | 100.0% | 1.00 |
+| `dev.constructive.eo.laws.data` | 29/29 | 100.0% | — | — | — |
+| `dev.constructive.eo.laws.data.discipline` | 21/21 | 100.0% | — | — | — |
+| `dev.constructive.eo.laws.discipline` | 190/190 | 100.0% | — | — | — |
+| `dev.constructive.eo.laws.discipline.internal` | 21/21 | 100.0% | — | — | — |
+| `dev.constructive.eo.laws.eo` | 65/65 | 100.0% | — | — | — |
+| `dev.constructive.eo.laws.eo.discipline` | 96/96 | 100.0% | — | — | — |
+| `dev.constructive.eo.laws.typeclass` | 29/29 | 100.0% | — | — | — |
+| `dev.constructive.eo.laws.typeclass.discipline` | 36/36 | 100.0% | — | — | — |
+| `dev.constructive.eo.optics` | 404/483 | 83.6% | 46/52 | 88.5% | 1.06 |
+| `dev.constructive.eo.schemes` | 187/187 | 100.0% | 35/35 | 100.0% | 1.00 |
+<!-- END GENERATED: coverage -->
+
+## Mutation testing
+
+stryker4s mutates each module's `main` sources and re-runs that module's own
+test suite per mutant. *Score (total)* counts no-coverage mutants against the
+score; *Score (covered)* is restricted to mutants on exercised lines. `Timeout`
+mutants count as detected (the mutant visibly broke the run). `Compile err`
+mutants — mutations that don't type-check, common in this codebase's
+match-type / opaque-carrier code — are excluded from both scores.
+
+**StringLiteral mutants are excluded build-wide**
+(`ThisBuild / strykerExcludedMutations`): in this codebase string literals are
+error messages, vestigial-arm labels, and discipline rule-set names — nothing
+any suite asserts on, so they survive as pure noise and drown the genuine
+survivors (in `laws`, 99 of 101 unfiltered survivors were rule-set name
+labels). They appear as *Ignored* in the HTML reports and are counted in no
+score.
+
+Caveats that keep the table honest:
+
+- **`core`** — its behavioural suite lives in the separate `tests/` module
+  (which depends on `laws` and `generics`, so core can't `dependsOn` it back —
+  that's a project cycle). `mutationAll` instead *task-borrows* the compiled
+  suite: it appends `tests/Test/definedTests` and `tests/Test/fullClasspath`
+  to core's Test scope for the mutation run only. This is sound because
+  stryker compiles every mutant into core's classes behind runtime switches
+  (binary-compatible), so specs compiled against unmutated core still
+  exercise the mutated bytecode. Core's row below is scored against the full
+  cross-module suite.
+- **`generics`** is macro code: it expands at *compile* time, so its mutants
+  leave no runtime footprint for a test *run* to cover. Mutation testing
+  structurally can't score it — the derived-optic laws in `generics/test`
+  guard it instead.
+- **`laws`** has no in-module tests, so it borrows the `tests/` suite the same
+  way core does. Mutating the law *definitions* is the "who tests the tests"
+  probe: a killed mutant means the discipline suites notice a corrupted law; a
+  survivor pinpoints a law whose discriminating power nothing exercises. The
+  surviving mutants are all *law-weakening* mutations (`missIsEmpty`'s guard →
+  `false` in `AffineFoldLaws`, `&&` → `||` in `ModifyFLaws.functorIdentity` /
+  `functorComposition`): every instance under test satisfies the weakened law
+  too, so nothing fails. Killing those requires **negative fixtures** —
+  deliberately unlawful instances pinned to fail the suite — which is the
+  concrete follow-up this table surfaces.
+
+Two modules can't currently be scored, for reasons worth recording:
+
+- **`jsoniter`** — instrumenting `PathParser.parseField` (one large byte-cursor
+  method) with its mutants overflows the JVM's 64 KB per-method bytecode limit,
+  so the sandbox won't compile. It's un-mutatable in place without splitting the
+  method or excluding it.
+- **`avro`** — stryker's forked test-runner fails to initialise in the sandbox
+  (the initial test run dies in well under a second, emitting no test output),
+  even though the same specs pass under plain `sbt test`. Reproduced under both
+  JDK 21 and JDK 25 with the default and legacy runners.
+
+The high-signal rows are therefore `core` and `laws` (via the borrowed suite),
+`schemes`, and `circe` — modules whose mutated code is genuinely exercised at
+run time by the suite stryker runs.
+
+<!-- BEGIN GENERATED: mutation -->
+| Module | Killed | Timeout | Survived | No&nbsp;cov | Compile&nbsp;err | Score (total) | Score (covered) | Notes |
+|---|--:|--:|--:|--:|--:|--:|--:|---|
+| `core` | 140 | 2 | 41 | 17 | 3 | 71.0% | 77.6% | Scored against the cross-module suite in `tests/`, task-borrowed into core's Test scope by `mutationAll`. |
+| `laws` | 80 | 0 | 3 | 0 | 0 | 96.4% | 96.4% | Borrowed `tests/` suite. Survivors are law-weakening mutations — see prose. |
+| `generics` | 0 | 0 | 0 | 58 | 0 | 0.0% | — | Macro code: it expands at compile time, so mutants leave no runtime footprint for the test run to cover. |
+| `schemes` | 58 | 0 | 18 | 0 | 5 | 76.3% | 76.3% |  |
+| `circe` | 33 | 1 | 5 | 15 | 0 | 63.0% | 87.2% |  |
+| `avro` | — | — | — | — | — | — | — | Not scored: stryker's forked test-runner fails to initialise in the sandbox (the specs pass under plain `sbt test`). |
+| `jsoniter` | — | — | — | — | — | — | — | Not scored: instrumenting `PathParser.parseField` blows the JVM 64 KB method-size limit — one giant byte-cursor method, un-mutatable in place. |
+<!-- END GENERATED: mutation -->
+
+## Regenerating these numbers
+
+```sh
+# Statement / branch coverage (cross-module aggregate):
+SBT_OPTS="-Xmx6g" sbt coverageAll
+#   → target/scala-3.8.3/scoverage-report/  (HTML + scoverage.xml)
+
+# Mutation testing across the runtime-logic modules:
+SBT_OPTS="-Xmx6g" sbt mutationAll
+#   → <module>/target/stryker4s-report/<ts>/  (index.html + report.json)
+
+# Rewrite the tables above from those reports + CompositionMatrixSpec:
+python3 site/tools/gen-qa-report.py            # in place
+python3 site/tools/gen-qa-report.py --check     # CI: non-zero if stale
+```
+
+Both aliases relax the always-on `-Werror` (`tlFatalWarnings`) first, since
+instrumented sources can surface `-Wunused` warnings; the larger heap is
+because the `set` reapply re-evaluates the Laika docs settings. Mutation runs
+with `project <m>; stryker` (not `<m>/stryker`) so specs2 is visible to the
+test runner — see
+[`project/plugins.sbt`](https://github.com/Constructive-Programming/eo/blob/main/project/plugins.sbt).
+
+The [`quality.yml`](https://github.com/Constructive-Programming/eo/blob/main/.github/workflows/quality.yml)
+workflow runs all three on every release tag (and on demand via
+`workflow_dispatch`), uploading the HTML reports and the regenerated tables as
+build artifacts.

--- a/site/docs/quality-assurance.md
+++ b/site/docs/quality-assurance.md
@@ -151,8 +151,8 @@ run time by the suite stryker runs.
 <!-- BEGIN GENERATED: mutation -->
 | Module | Killed | Timeout | Survived | No&nbsp;cov | Compile&nbsp;err | Score (total) | Score (covered) | Notes |
 |---|--:|--:|--:|--:|--:|--:|--:|---|
-| `core` | 140 | 2 | 41 | 17 | 3 | 71.0% | 77.6% | Scored against the cross-module suite in `tests/`, task-borrowed into core's Test scope by `mutationAll`. |
-| `laws` | 80 | 0 | 3 | 0 | 0 | 96.4% | 96.4% | Borrowed `tests/` suite. Survivors are law-weakening mutations — see prose. |
+| `core` | 153 | 2 | 28 | 17 | 3 | 77.5% | 84.7% | Scored against the cross-module suite in `tests/`, task-borrowed into core's Test scope by `mutationAll`. |
+| `laws` | 82 | 1 | 0 | 0 | 0 | 100.0% | 100.0% | Borrowed `tests/` suite. Survivors are law-weakening mutations — see prose. |
 | `generics` | 0 | 0 | 0 | 58 | 0 | 0.0% | — | Macro code: it expands at compile time, so mutants leave no runtime footprint for the test run to cover. |
 | `schemes` | 58 | 0 | 18 | 0 | 5 | 76.3% | 76.3% |  |
 | `circe` | 33 | 1 | 5 | 15 | 0 | 63.0% | 87.2% |  |

--- a/site/docs/quality-assurance.md
+++ b/site/docs/quality-assurance.md
@@ -152,7 +152,7 @@ run time by the suite stryker runs.
 | Module | Killed | Timeout | Survived | No&nbsp;cov | Compile&nbsp;err | Score (total) | Score (covered) | Notes |
 |---|--:|--:|--:|--:|--:|--:|--:|---|
 | `core` | 153 | 2 | 28 | 17 | 3 | 77.5% | 84.7% | Scored against the cross-module suite in `tests/`, task-borrowed into core's Test scope by `mutationAll`. |
-| `laws` | 82 | 1 | 0 | 0 | 0 | 100.0% | 100.0% | Borrowed `tests/` suite. Survivors are law-weakening mutations — see prose. |
+| `laws` | 82 | 1 | 0 | 0 | 0 | 100.0% | 100.0% | Borrowed `tests/` suite; the negative fixtures in `UnlawfulFixturesSpec` keep the law-weakening mutants dead — see prose. |
 | `generics` | 0 | 0 | 0 | 58 | 0 | 0.0% | — | Macro code: it expands at compile time, so mutants leave no runtime footprint for the test run to cover. |
 | `schemes` | 58 | 0 | 18 | 0 | 5 | 76.3% | 76.3% |  |
 | `circe` | 33 | 1 | 5 | 15 | 0 | 63.0% | 87.2% |  |

--- a/site/tools/gen-qa-report.py
+++ b/site/tools/gen-qa-report.py
@@ -52,7 +52,7 @@ FAMILIES = [
 # appears, its numbers take over and the note still annotates the row.
 MUTATION_MODULES = [
     ("core", "core", "Scored against the cross-module suite in `tests/`, task-borrowed into core's Test scope by `mutationAll`."),
-    ("laws", "laws", "Borrowed `tests/` suite. Survivors are law-weakening mutations — see prose."),
+    ("laws", "laws", "Borrowed `tests/` suite; the negative fixtures in `UnlawfulFixturesSpec` keep the law-weakening mutants dead — see prose."),
     ("generics", "generics", "Macro code: it expands at compile time, so mutants leave no runtime footprint for the test run to cover."),
     ("schemes", "schemes", ""),
     ("circe", "circe", ""),

--- a/site/tools/gen-qa-report.py
+++ b/site/tools/gen-qa-report.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Regenerate the data tables on site/docs/quality-assurance.md.
+
+Three tables, each written between a `<!-- BEGIN GENERATED: <id> -->` /
+`<!-- END GENERATED: <id> -->` marker pair so the hand-authored prose around
+them is preserved:
+
+  - matrix   : the composition matrix as a pass (✓) / fail (✗) map, parsed
+               straight from tests/.../CompositionMatrixSpec.scala (the spec is
+               the single source of truth — every `typeChecks(...) must beTrue`
+               is a cell that composes, every `must beFalse` a void-by-design
+               cell).
+  - coverage : per-package statement % and branch % with their BC/SC ratio,
+               computed from the scoverage AGGREGATE report by counting
+               <statement> elements directly (matches scoverage's own
+               definition; doesn't trust the rate attributes).
+  - mutation : per-module stryker4s results (killed / survived / no-coverage /
+               compile-error / score) from each module's latest
+               target/stryker4s-report/<ts>/report.json (schema v2).
+
+Run after `sbt coverageAll` and `sbt mutationAll` (see build.sbt aliases). Both
+the developer and .github/workflows/quality.yml invoke this. Idempotent:
+re-running with the same inputs yields no diff.
+
+    python3 site/tools/gen-qa-report.py            # rewrite the page in place
+    python3 site/tools/gen-qa-report.py --check     # exit 1 if it would change
+"""
+import glob
+import json
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PAGE = os.path.join(ROOT, "site", "docs", "quality-assurance.md")
+SPEC = os.path.join(
+    ROOT, "tests", "src", "test", "scala", "dev", "constructive", "eo",
+    "CompositionMatrixSpec.scala",
+)
+
+# Outer/inner family order — matches the spec's row order and the optics.md
+# taxonomy. `trav` = Traversal, `affold` = AffineFold.
+FAMILIES = [
+    "iso", "lens", "prism", "optional", "trav",
+    "getter", "affold", "fold", "modify", "review", "unfold",
+]
+
+# Modules stryker mutates. value = (on-disk module dir, human label, note).
+# The note is the Notes-column caveat; for modules that can't be scored it
+# doubles as the "why" shown when no report.json exists. If a report later
+# appears, its numbers take over and the note still annotates the row.
+MUTATION_MODULES = [
+    ("core", "core", "Scored against the cross-module suite in `tests/`, task-borrowed into core's Test scope by `mutationAll`."),
+    ("laws", "laws", "Borrowed `tests/` suite. Survivors are law-weakening mutations — see prose."),
+    ("generics", "generics", "Macro code: it expands at compile time, so mutants leave no runtime footprint for the test run to cover."),
+    ("schemes", "schemes", ""),
+    ("circe", "circe", ""),
+    ("avro", "avro", "Not scored: stryker's forked test-runner fails to initialise in the sandbox (the specs pass under plain `sbt test`)."),
+    ("jsoniter", "jsoniter", "Not scored: instrumenting `PathParser.parseField` blows the JVM 64 KB method-size limit — one giant byte-cursor method, un-mutatable in place."),
+]
+
+
+def splice(page: str, marker: str, body: str) -> str:
+    """Replace the content between BEGIN/END GENERATED markers for `marker`."""
+    begin = f"<!-- BEGIN GENERATED: {marker} -->"
+    end = f"<!-- END GENERATED: {marker} -->"
+    pat = re.compile(re.escape(begin) + r".*?" + re.escape(end), re.DOTALL)
+    if not pat.search(page):
+        raise SystemExit(f"marker pair for '{marker}' not found in {PAGE}")
+    return pat.sub(f"{begin}\n{body}\n{end}", page)
+
+
+# --------------------------------------------------------------------------
+# matrix
+# --------------------------------------------------------------------------
+def gen_matrix() -> str:
+    src = open(SPEC, encoding="utf-8").read()
+    # Cell titles read `"<outer> ∘ <inner> ..." >>`; the verdict is the first
+    # `typeChecks("...andThen...") must beTrue|beFalse` inside the cell block.
+    cell_re = re.compile(r'"(\w+)\s*∘\s*(\w+)[^"]*"\s*>>')
+    verdict_re = re.compile(r"must\s+(beTrue|beFalse)")
+    cells = {}
+    matches = list(cell_re.finditer(src))
+    for i, m in enumerate(matches):
+        outer, inner = m.group(1), m.group(2)
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(src)
+        block = src[m.end():end]
+        v = verdict_re.search(block)
+        if v:
+            cells[(outer, inner)] = v.group(1) == "beTrue"
+
+    head = "| outer ∘ inner | " + " | ".join(FAMILIES) + " |"
+    sep = "|" + "---|" * (len(FAMILIES) + 1)
+    rows = [head, sep]
+    n_pass = n_fail = 0
+    for o in FAMILIES:
+        line = [f"**{o}**"]
+        for i in FAMILIES:
+            ok = cells.get((o, i))
+            if ok is None:
+                line.append("·")
+            elif ok:
+                line.append("✓")
+                n_pass += 1
+            else:
+                line.append("✗")
+                n_fail += 1
+        rows.append("| " + " | ".join(line) + " |")
+    legend = (
+        f"\n*✓ composes import-free at the strength shown in the "
+        f"[optic taxonomy](optics.md); ✗ does not compile (void by design — "
+        f"building through a read-only optic, reading through a write-only one, "
+        f"etc.). {n_pass} composing / {n_fail} void cells, pinned by "
+        f"`CompositionMatrixSpec`.*"
+    )
+    return "\n".join(rows) + "\n" + legend
+
+
+# --------------------------------------------------------------------------
+# coverage
+# --------------------------------------------------------------------------
+def find_scoverage_xml() -> str:
+    pats = [
+        os.path.join(ROOT, "target", "scala-*", "scoverage-report", "scoverage.xml"),
+    ]
+    hits = []
+    for p in pats:
+        hits += glob.glob(p)
+    if not hits:
+        return ""
+    return max(hits, key=os.path.getmtime)
+
+
+def gen_coverage() -> str:
+    xml = find_scoverage_xml()
+    if not xml:
+        return ("> _No scoverage aggregate report found. Run `sbt coverageAll`, "
+                "then re-run `site/tools/gen-qa-report.py`._")
+    root = ET.parse(xml).getroot()
+    rows = [
+        "| Package | Statements | Stmt&nbsp;% | Branches | Branch&nbsp;% | BC/SC |",
+        "|---|--:|--:|--:|--:|--:|",
+    ]
+    packages = root.find("packages")
+    pkgs = packages.findall("package") if packages is not None else []
+    for pkg in sorted(pkgs, key=lambda p: p.get("name", "")):
+        name = pkg.get("name", "")
+        stmts = pkg.findall(".//statement")
+        total = len(stmts)
+        if total == 0:
+            continue
+        invoked = sum(1 for s in stmts if int(s.get("invocation-count", "0")) > 0)
+        bstmts = [s for s in stmts if s.get("branch", "false") == "true"]
+        btotal = len(bstmts)
+        binvoked = sum(1 for s in bstmts if int(s.get("invocation-count", "0")) > 0)
+        srate = 100.0 * invoked / total
+        if btotal:
+            brate = 100.0 * binvoked / btotal
+            bcell = f"{binvoked}/{btotal}"
+            bpct = f"{brate:.1f}%"
+            ratio = f"{brate / srate:.2f}" if srate else "—"
+        else:
+            bcell, bpct, ratio = "—", "—", "—"
+        rows.append(
+            f"| `{name}` | {invoked}/{total} | {srate:.1f}% | {bcell} | {bpct} | {ratio} |"
+        )
+    return "\n".join(rows)
+
+
+# --------------------------------------------------------------------------
+# mutation
+# --------------------------------------------------------------------------
+def latest_report(module_dir: str) -> str:
+    pat = os.path.join(ROOT, module_dir, "target", "stryker4s-report", "*", "report.json")
+    hits = glob.glob(pat)
+    return max(hits, key=os.path.getmtime) if hits else ""
+
+
+# circe/avro/jsoniter sbt ids map to these on-disk directories.
+MODULE_DIR = {
+    "core": "core", "laws": "laws", "generics": "generics", "schemes": "schemes",
+    "circe": "circe", "avro": "avro", "jsoniter": "jsoniter",
+}
+
+
+def gen_mutation() -> str:
+    rows = [
+        "| Module | Killed | Timeout | Survived | No&nbsp;cov | Compile&nbsp;err | Score (total) | Score (covered) | Notes |",
+        "|---|--:|--:|--:|--:|--:|--:|--:|---|",
+    ]
+    any_report = False
+    for proj, label, note in MUTATION_MODULES:
+        rep = latest_report(MODULE_DIR[proj])
+        if not rep:
+            why = note if note else "_no report — run `sbt mutationAll`_"
+            rows.append(f"| `{label}` | — | — | — | — | — | — | — | {why} |")
+            continue
+        any_report = True
+        data = json.load(open(rep, encoding="utf-8"))
+        counts = {}
+        for f in data.get("files", {}).values():
+            for m in f.get("mutants", []):
+                counts[m["status"]] = counts.get(m["status"], 0) + 1
+        killed = counts.get("Killed", 0)
+        survived = counts.get("Survived", 0)
+        nocov = counts.get("NoCoverage", 0)
+        timeout = counts.get("Timeout", 0)
+        cerr = counts.get("CompileError", 0)
+        detected = killed + timeout
+        scored = detected + survived + nocov
+        covered = detected + survived
+        total_score = f"{100.0 * detected / scored:.1f}%" if scored else "—"
+        cov_score = f"{100.0 * detected / covered:.1f}%" if covered else "—"
+        rows.append(
+            f"| `{label}` | {killed} | {timeout} | {survived} | {nocov} | {cerr} | "
+            f"{total_score} | {cov_score} | {note} |"
+        )
+    if not any_report:
+        return ("> _No stryker4s reports found. Run `sbt mutationAll`, then "
+                "re-run `site/tools/gen-qa-report.py`._")
+    return "\n".join(rows)
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+    page = open(PAGE, encoding="utf-8").read()
+    out = page
+    out = splice(out, "matrix", gen_matrix())
+    out = splice(out, "coverage", gen_coverage())
+    out = splice(out, "mutation", gen_mutation())
+    if out == page:
+        print("quality-assurance.md already up to date.")
+        return 0
+    if check:
+        print("quality-assurance.md is OUT OF DATE (run gen-qa-report.py).")
+        return 1
+    open(PAGE, "w", encoding="utf-8").write(out)
+    print(f"Wrote {PAGE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/src/test/scala/dev/constructive/eo/InternalsCoverageSpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/InternalsCoverageSpec.scala
@@ -191,3 +191,22 @@ class InternalsCoverageSpec extends Specification:
     MultiFocusK.pickSingletonOrThrow[List, Int](List.empty[Int], "test") must
       throwAn[IllegalStateException]
   }
+
+  // covers: the dead contract corners mutation testing flagged NoCoverage —
+  //   Affine.Miss/Hit equals false-arms (Affine.scala:92/:107): cross-variant comparison,
+  //   Hit.hashCode null guard (:109): hashing a null focus must be total,
+  //   PSVec equals false-arm (PSVec.scala:71): comparison against a non-PSVec,
+  //   Foldable[PSVec].foldRight (:132): the Eval loop's boundary and accumulation.
+  "dead contract corners: cross-variant equality, null hashing, foldRight" >> {
+    val miss = new Affine.Miss[(Int, String), Int](1)
+    val hit = new Affine.Hit[(Int, String), Int]("s", 1)
+    val crossOk = !miss.equals(hit) && !hit.equals(miss) && !miss.equals("x")
+    val nullHit = new Affine.Hit[(Int, String), String]("s", null)
+    val nullHashOk = nullHit.hashCode == nullHit.hashCode
+    val vec = PSVec.fromIterable(List(1, 2, 3))
+    val notAVecOk = !vec.equals("not a vector")
+    val folded = cats.Foldable[PSVec]
+      .foldRight(vec, cats.Eval.now(List.empty[Int]))((a, eb) => eb.map(a :: _))
+      .value
+    (crossOk, nullHashOk, notAVecOk, folded) must beEqualTo((true, true, true, List(1, 2, 3)))
+  }

--- a/tests/src/test/scala/dev/constructive/eo/InternalsCoverageSpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/InternalsCoverageSpec.scala
@@ -2,7 +2,7 @@ package dev.constructive.eo
 
 import org.specs2.mutable.Specification
 
-import data.{Affine, IntArrBuilder, MultiFocusK, ObjArrBuilder, PSVec}
+import data.{Affine, IntArrBuilder, MultiFocusFromList, MultiFocusK, ObjArrBuilder, PSVec}
 
 /** Direct coverage for internal machinery that shipped without user-facing specs.
   *
@@ -209,4 +209,20 @@ class InternalsCoverageSpec extends Specification:
       .foldRight(vec, cats.Eval.now(List.empty[Int]))((a, eb) => eb.map(a :: _))
       .value
     (crossOk, nullHashOk, notAVecOk, folded) must beEqualTo((true, true, true, List(1, 2, 3)))
+  }
+
+  // covers: the remaining cold paths —
+  //   PSVec base toAnyRefArray (PSVec.scala:49): only Empty reaches it (Single/Slice
+  //   override); boundary mutants make the vacuous loop call the throwing Empty.apply(0);
+  //   MultiFocusFromList.forPSVec.fromList loop (MultiFocus.scala:106): a skipped loop
+  //   wraps a null-filled array;
+  //   Affine.Hit.hashCode null-guard `true` (Affine.scala:109): collapses to a
+  //   snd-only hash — pinned-witness canary, not a contract claim.
+  "cold paths: Empty.toAnyRefArray, fromList loop, Hit hash discrimination" >> {
+    val emptyArrOk = PSVec.empty[Int].toAnyRefArray.length == 0
+    val viaFromList = MultiFocusFromList.forPSVec.fromList(List(1, 2, 3))
+    val fromListOk = viaFromList == PSVec.fromIterable(List(1, 2, 3))
+    val h1 = new Affine.Hit[(Int, String), Int]("s", 1).hashCode
+    val h2 = new Affine.Hit[(Int, String), Int]("s", 2).hashCode
+    (emptyArrOk, fromListOk, h1 == h2) must beEqualTo((true, true, false))
   }

--- a/tests/src/test/scala/dev/constructive/eo/InternalsCoverageSpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/InternalsCoverageSpec.scala
@@ -2,7 +2,7 @@ package dev.constructive.eo
 
 import org.specs2.mutable.Specification
 
-import data.{IntArrBuilder, ObjArrBuilder, PSVec}
+import data.{Affine, IntArrBuilder, MultiFocusK, ObjArrBuilder, PSVec}
 
 /** Direct coverage for internal machinery that shipped without user-facing specs.
   *
@@ -169,4 +169,25 @@ class InternalsCoverageSpec extends Specification:
     val partialOk = (out.length === 1).and(out(0) === "x")
 
     exactOk.and(growOk).and(partialOk)
+  }
+
+  // covers: Affine.Hit.equals conjunction (Affine.scala:106) — equal snd with different b
+  // must discriminate; an `||`-weakened equals would accept it.
+  "Affine.Hit equality discriminates on each component independently" >> {
+    val base = new Affine.Hit[(Int, String), Int]("s", 1)
+    val sameSndDiffB = new Affine.Hit[(Int, String), Int]("s", 2)
+    val diffSndSameB = new Affine.Hit[(Int, String), Int]("t", 1)
+    (base == sameSndDiffB) must beFalse
+    (base == diffSndSameB) must beFalse
+  }
+
+  // covers: MultiFocusK.pickSingletonOrThrow cardinality guard (MultiFocus.scala:245) —
+  // weakened to `true` it silently returns the LAST element of a multi-focus instead of
+  // raising the Composer cardinality error.
+  "pickSingletonOrThrow returns the singleton and throws on any other cardinality" >> {
+    MultiFocusK.pickSingletonOrThrow[List, Int](List(7), "test") must beEqualTo(7)
+    MultiFocusK.pickSingletonOrThrow[List, Int](List(1, 2), "test") must
+      throwAn[IllegalStateException]
+    MultiFocusK.pickSingletonOrThrow[List, Int](List.empty[Int], "test") must
+      throwAn[IllegalStateException]
   }

--- a/tests/src/test/scala/dev/constructive/eo/PSVecBoundarySpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/PSVecBoundarySpec.scala
@@ -1,0 +1,74 @@
+package dev.constructive.eo
+
+import org.scalacheck.{Gen, Prop}
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+import optics.Traversal
+import data.PSVec
+
+/** Capacity-boundary and contract checks for the PSVec/builder machinery, driven through the
+  * public composed-traversal surface.
+  *
+  * The grow-on-demand builders (`ObjArrBuilder`, `IntArrBuilder`) start at capacity 16 and the
+  * default generators rarely cross that line through the slice-append path, so the grow-guard
+  * conditionals survived mutation testing: a corrupted guard only crashes
+  * (ArrayIndexOutOfBoundsException) once a single flatten step exceeds the remaining capacity.
+  * The generators here straddle the boundary on purpose — inner lists up to 48 elements force
+  * `appendAllFromPSVec`'s bulk-grow, outer lists up to 24 force the per-element counts builder
+  * past 16.
+  */
+class PSVecBoundarySpec extends Specification with ScalaCheck:
+
+  private val outerTrav = Traversal.each[List, List[Int]]
+  private val innerTrav = Traversal.each[List, Int]
+  private val composed = outerTrav.andThen(innerTrav)
+
+  // Sizes biased around the builders' initial capacity (16): empties, singletons, and
+  // slices well past the growth boundary, in long outer lists.
+  private val nested: Gen[List[List[Int]]] =
+    val inner = Gen.oneOf(
+      Gen.const(Nil),
+      Gen.listOfN(1, Gen.choose(-10, 10)),
+      Gen.choose(15, 48).flatMap(n => Gen.listOfN(n, Gen.choose(-10, 10))),
+    )
+    Gen.choose(0, 24).flatMap(n => Gen.listOfN(n, inner))
+
+  "trav ∘ trav foldMap equals flatten-sum across the capacity boundary" >> {
+    // covers: ObjArrBuilder.appendAllFromPSVec grow guard + grow loop (lines 32/38),
+    //         IntArrBuilder append guard (line 15) — a corrupted guard crashes here.
+    Prop.forAll(nested) { xs =>
+      val got: Int = composed.foldMap(identity[Int])(xs)
+      val want: Int = xs.map(_.sum).sum
+      got == want
+    }
+  }
+
+  "trav ∘ trav modify equals nested map across the capacity boundary" >> {
+    // covers: the same builder paths on the write side, plus PSVec slice/wrap edges.
+    Prop.forAll(nested) { xs =>
+      val got: List[List[Int]] = composed.modify(_ + 1)(xs)
+      val want: List[List[Int]] = xs.map(_.map(_ + 1))
+      got == want
+    }
+  }
+
+  "PSVec equality discriminates prefix-equal vectors of different lengths" >> {
+    // covers: PSVec.equals length guard (line 67) — `!=` weakened to `>` or dropped
+    // accepts a shorter prefix-equal vector.
+    val shorter = PSVec.fromIterable(List(1, 2))
+    val longer = PSVec.fromIterable(List(1, 2, 3))
+    (shorter == longer) must beFalse
+    (longer == shorter) must beFalse
+  }
+
+  "structurally equal PSVecs hash equally (and hashing terminates)" >> {
+    // covers: PSVec.hashCode loop condition (line 78) — the `true` mutant loops forever,
+    // so merely hashing a non-empty vector detects it (timeout). Equal-hash asserted on
+    // vectors built through different constructors so the contract is exercised, not an
+    // implementation echo.
+    val viaIterable = PSVec.fromIterable(List(1, 2, 3))
+    val viaSlice = PSVec.fromIterable(List(0, 1, 2, 3, 4)).slice(1, 4)
+    (viaIterable == viaSlice) must beTrue
+    viaIterable.hashCode must beEqualTo(viaSlice.hashCode)
+  }

--- a/tests/src/test/scala/dev/constructive/eo/PSVecBoundarySpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/PSVecBoundarySpec.scala
@@ -7,16 +7,15 @@ import org.specs2.mutable.Specification
 import optics.Traversal
 import data.PSVec
 
-/** Capacity-boundary and contract checks for the PSVec/builder machinery, driven through the
-  * public composed-traversal surface.
+/** Capacity-boundary and contract checks for the PSVec/builder machinery, driven through the public
+  * composed-traversal surface.
   *
   * The grow-on-demand builders (`ObjArrBuilder`, `IntArrBuilder`) start at capacity 16 and the
   * default generators rarely cross that line through the slice-append path, so the grow-guard
   * conditionals survived mutation testing: a corrupted guard only crashes
-  * (ArrayIndexOutOfBoundsException) once a single flatten step exceeds the remaining capacity.
-  * The generators here straddle the boundary on purpose — inner lists up to 48 elements force
-  * `appendAllFromPSVec`'s bulk-grow, outer lists up to 24 force the per-element counts builder
-  * past 16.
+  * (ArrayIndexOutOfBoundsException) once a single flatten step exceeds the remaining capacity. The
+  * generators here straddle the boundary on purpose — inner lists up to 48 elements force
+  * `appendAllFromPSVec`'s bulk-grow, outer lists up to 24 force the per-element counts builder past 16.
   */
 class PSVecBoundarySpec extends Specification with ScalaCheck:
 
@@ -60,6 +59,33 @@ class PSVecBoundarySpec extends Specification with ScalaCheck:
     val longer = PSVec.fromIterable(List(1, 2, 3))
     (shorter == longer) must beFalse
     (longer == shorter) must beFalse
+  }
+
+  "PSVec equality discriminates same-length different-content vectors" >> {
+    // covers: PSVec.equals elementwise while-loop (line 67) — loop-skipping mutants
+    // (condition → false / i > length) accept ANY same-length pair; the length guard
+    // above never fires for these.
+    val a = PSVec.fromIterable(List(1, 2, 3))
+    val b = PSVec.fromIterable(List(1, 9, 3))
+    (a == b) must beFalse
+  }
+
+  "unequal PSVecs of equal length hash differently (pinned witness)" >> {
+    // covers: PSVec.hashCode while-loop (line 76) and null-guard `true` (line 78) —
+    // loop-skipping mutants collapse every hash to 1, the always-null guard to a
+    // length-only hash. The hashCode CONTRACT doesn't promise inequality; this
+    // deterministic witness pair hashes apart under the real polynomial hash, so it is
+    // a canary for hash-collapse, not a contract claim.
+    val a = PSVec.fromIterable(List(1, 2))
+    val b = PSVec.fromIterable(List(3, 4))
+    (a.hashCode == b.hashCode) must beFalse
+  }
+
+  "hashing a null-bearing PSVec is total" >> {
+    // covers: PSVec.hashCode null guard (line 78) — a flipped or dropped guard NPEs on
+    // null elements.
+    val withNull = PSVec.fromIterable(List("a", null, "b"))
+    withNull.hashCode must beEqualTo(withNull.hashCode)
   }
 
   "structurally equal PSVecs hash equally (and hashing terminates)" >> {

--- a/tests/src/test/scala/dev/constructive/eo/PlatedSpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/PlatedSpec.scala
@@ -245,3 +245,26 @@ class PlatedSpec extends Specification with Discipline:
 
     descentOk && refireOk
   }
+
+  "transform rewrites the FULL depth of a spine that crosses the machine handoff" >> {
+    // covers: Plated.transformMachine internals (enter's leaf check at line 146, the
+    // drain loop at line 149). The 100k stack-safety test above reaches the machine but
+    // only asserts shallow shape, so a machine that returns its subtree UNCHANGED
+    // (drain loop skipped) survived. This pins the deepest leaf and the spine length
+    // after a transform that crosses transformRecursionLimit (512).
+    val depth = 1500
+    var deep: Bin = Bin.Leaf(0)
+    var i = 0
+    while i < depth do
+      deep = Bin.Node(deep, Bin.Leaf(1))
+      i += 1
+    val bump: Bin => Bin = { case Bin.Leaf(k) => Bin.Leaf(k + 1); case n => n }
+    val bumped = Plated.transform(bump)(deep)(using PlatedFixtures.platedBin)
+    def leftmost(b: Bin, d: Int): (Int, Int) = b match
+      case Bin.Node(l, _) => leftmost(l, d + 1)
+      case Bin.Leaf(k)    => (d, k)
+    val topRight = bumped match
+      case Bin.Node(_, Bin.Leaf(k)) => k
+      case _                        => -1
+    (leftmost(bumped, 0), topRight) must beEqualTo(((depth, 1), 2))
+  }

--- a/tests/src/test/scala/dev/constructive/eo/UnlawfulFixturesSpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/UnlawfulFixturesSpec.scala
@@ -12,11 +12,11 @@ import laws.data.ModifyFLaws
   *
   * Discipline registrations can only witness that lawful instances pass; they can never witness
   * that a law *discriminates*. A law-weakening mutation (a guard short-circuited to `false`, an
-  * `&&` flipped to `||`) leaves every lawful instance passing, so the whole borrowed suite is
-  * blind to it — mutation testing surfaced exactly three such survivors in `cats-eo-laws`. Each
-  * fixture below is minimally unlawful: it violates precisely the clause the mutant weakens, so
-  * the law method must return `false` here, and any weakening of that clause flips the result to
-  * `true` and fails this spec.
+  * `&&` flipped to `||`) leaves every lawful instance passing, so the whole borrowed suite is blind
+  * to it — mutation testing surfaced exactly three such survivors in `cats-eo-laws`. Each fixture
+  * below is minimally unlawful: it violates precisely the clause the mutant weakens, so the law
+  * method must return `false` here, and any weakening of that clause flips the result to `true` and
+  * fails this spec.
   *
   * See site/docs/quality-assurance.md ("Mutation testing" caveats) for the full story.
   */

--- a/tests/src/test/scala/dev/constructive/eo/UnlawfulFixturesSpec.scala
+++ b/tests/src/test/scala/dev/constructive/eo/UnlawfulFixturesSpec.scala
@@ -1,0 +1,68 @@
+package dev.constructive.eo
+
+import org.specs2.mutable.Specification
+
+import optics.AffineFold
+import data.ModifyF
+import forgetful.ForgetfulFunctor
+import laws.AffineFoldLaws
+import laws.data.ModifyFLaws
+
+/** Negative fixtures: deliberately UNLAWFUL instances asserted to FAIL specific laws.
+  *
+  * Discipline registrations can only witness that lawful instances pass; they can never witness
+  * that a law *discriminates*. A law-weakening mutation (a guard short-circuited to `false`, an
+  * `&&` flipped to `||`) leaves every lawful instance passing, so the whole borrowed suite is
+  * blind to it — mutation testing surfaced exactly three such survivors in `cats-eo-laws`. Each
+  * fixture below is minimally unlawful: it violates precisely the clause the mutant weakens, so
+  * the law method must return `false` here, and any weakening of that clause flips the result to
+  * `true` and fails this spec.
+  *
+  * See site/docs/quality-assurance.md ("Mutation testing" caveats) for the full story.
+  */
+class UnlawfulFixturesSpec extends Specification:
+
+  "AffineFoldLaws.missIsEmpty rejects a Miss/foldMap-inconsistent instance" >> {
+    // covers: laws/AffineFoldLaws.scala missIsEmpty guard (ConditionalExpression → false).
+    // Stateful `to`: the law's getOption sees a Miss, its foldMap then sees a Hit — an
+    // impure, unlawful optic (purity is an implicit law). Unmutated law: Miss branch
+    // compares foldMap(identity) = 7 with Monoid[Int].empty = 0 → false. Weakened guard
+    // skips the Miss branch entirely → vacuously true → this expectation fails.
+    val brokenAf: AffineFold[Int, Int] =
+      var calls = 0
+      AffineFold[Int, Int] { _ =>
+        calls += 1
+        if calls == 1 then None else Some(7)
+      }
+    val laws = new AffineFoldLaws[Int, Int]:
+      def af = brokenAf
+    laws.missIsEmpty(0, identity) must beFalse
+  }
+
+  "ModifyFLaws.functorIdentity rejects a continuation-corrupting functor" >> {
+    // covers: laws/data/ModifyFLaws.scala functorIdentity (&& → ||).
+    // This functor preserves the source (first conjunct TRUE) but discards the mapped
+    // continuation (second conjunct FALSE): && → false, || → true. `null.asInstanceOf[C]`
+    // unboxes to 0 for C = Int, and the fixture's fn returns 7 ≠ 0.
+    given broken: ForgetfulFunctor[ModifyF] with
+      def map[X, B, C](fa: ModifyF[X, B], f: B => C): ModifyF[X, C] =
+        ModifyF((fa.modifier._1, _ => null.asInstanceOf[C]))
+    val laws = new ModifyFLaws[(Int, String), Int] {}
+    laws.functorIdentity(1, _ => 7, "x") must beFalse
+  }
+
+  "ModifyFLaws.functorComposition rejects a first-call-corrupting functor" >> {
+    // covers: laws/data/ModifyFLaws.scala functorComposition (&& → ||).
+    // Corrupts only the FIRST map call — the inner map of the law's two-step lhs — so
+    // lhs's continuation diverges from rhs's while both sources stay equal: first
+    // conjunct TRUE, second FALSE. lhs._2(x) = g(null→0 + 1) = 2; rhs._2(x) =
+    // g(f(fn("abc"))) = 3 + 1 + 1 = 5.
+    given broken: ForgetfulFunctor[ModifyF] with
+      var calls = 0
+      def map[X, B, C](fa: ModifyF[X, B], f: B => C): ModifyF[X, C] =
+        calls += 1
+        if calls == 1 then ModifyF((fa.modifier._1, _ => null.asInstanceOf[C]))
+        else ModifyF((fa.modifier._1, x => f(fa.modifier._2(x))))
+    val laws = new ModifyFLaws[(Int, String), Int] {}
+    laws.functorComposition(1, _.length, _ + 1, _ + 1, "abc") must beFalse
+  }


### PR DESCRIPTION
## What

Reintroduces mutation testing (sbt-stryker4s 0.20.3) alongside scoverage, surfaces both on a generated **Quality Assurance** docs page, and ships an `improve-test-leverage` skill that uses the two reports to optimize the test suite's kill capacity per line of test code.

### Build wiring

- **`mutationAll` / `coverageAll` aliases.** Mutation runs per module via `project <m>; stryker` — the module-scoped `<m>/stryker` form resolves `loadedTestFrameworks` from the aggregating root project and reports 100% NoCoverage.
- **core and laws are scored against the `tests/` suite via task-level borrowing.** `core.dependsOn(tests % Test)` would cycle (tests → laws/generics → core); cross-project *task* references are legal. Sound because stryker compiles mutants behind binary-compatible runtime switches, so specs compiled against unmutated modules still exercise mutated bytecode. Measured: core 3% → **71.0% / 77.6% covered**; laws unscoreable → **96.4%**.
- **StringLiteral mutants excluded build-wide** — error messages, vestigial-arm labels, discipline rule-set names; nothing any suite asserts on (in laws, 99 of 101 unfiltered survivors were name labels).
- It's a report, not a gate: `strykerThresholdsBreak := 0`.

### QA page (`site/docs/quality-assurance.md`)

Three tables regenerated between markers by `site/tools/gen-qa-report.py` (idempotent, `--check` mode for CI):

1. the 11×11 **composition matrix** pass/fail map parsed from `CompositionMatrixSpec` (87 composing / 34 void-by-design cells);
2. per-package **statement/branch coverage with BC/SC ratio** from the scoverage aggregate (80.6% / 71.6% on this baseline);
3. per-module **mutation results** with honest caveats.

The laws survivors document a real finding: all genuine survivors are *law-weakening* mutations (`missIsEmpty` guard → `false`, `&&` → `||` in `ModifyFLaws`) — killable only by **negative fixtures** (deliberately unlawful instances pinned to fail), a concrete follow-up.

### Release workflow (`.github/workflows/quality.yml`)

Hand-written (separate from the generated `ci.yml`): on `v*` tags + manual dispatch, runs both sweeps (per-module so one failure doesn't abort the rest), regenerates the page, uploads HTML/JSON reports as artifacts.

### Skill (`.claude/skills/improve-test-leverage`, pinned to Sonnet)

Triages surviving mutants into algebraic leverage tiers (law promotion → ruleset registration → composed-optic laws → negative fixtures → properties → examples) with a placement rule exploiting the borrowed `tests/` suite; supports a measured eval-optimization loop (kills + branches per net test line, accept/revert per candidate, convergence detection) and a user-gated law-promotion path that elevates universal properties into the published `cats-eo-laws` artifact.

## Known limits (documented in the QA page)

- `generics` is macro code — expands at compile time, no runtime mutants to cover (law specs in `generics/test` guard it).
- `avro`: stryker's forked test-runner fails to initialise in its sandbox (specs pass under plain `sbt test`); reproduced across JDK 21/25, default and legacy runners.
- `jsoniter`: instrumenting `PathParser.parseField` overflows the JVM 64 KB method limit; StringLiteral exclusion does not rescue it (13/421) — needs the method split.

## Verification

- Both sweeps run green end-to-end on this branch (numbers in the page are measured from this baseline, not asserted).
- `gen-qa-report.py` idempotent; `docs/mdoc` + `docs/laikaSite` build with the new page; `scalafmtSbtCheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)